### PR TITLE
fix(postcss): extract plugins configurations

### DIFF
--- a/cssCompiler/css-pipeline.js
+++ b/cssCompiler/css-pipeline.js
@@ -1,25 +1,10 @@
-const autoprefixer = require('autoprefixer')
 const postcss = require('postcss')
 const scssSyntax = require('postcss-scss')
-const nodeSass = require('postcss-node-sass')
-const stylelint = require('stylelint')
-const reporter = require('postcss-reporter')
-
-const styleLintConfig = require('./styleLintConfig')
-
-const plugins = [
-  stylelint({ config: styleLintConfig }),
-  reporter({ clearReportedMessages: true }),
-  nodeSass({ includePaths: ['src/styles/'] }),
-  autoprefixer({
-    grid: 'autoplace',
-    browsers: ['> 1%'],
-  }),
-]
+const postCssPluginConfig = require('./postcssPluginConfig')
 
 const cssCompiler = (scss, pathFrom, pathTo) =>
   new Promise((resolve, reject) => {
-    postcss(plugins)
+    postcss(postCssPluginConfig)
       .process(scss, {
         from: pathFrom,
         to: pathTo,

--- a/cssCompiler/postcssPluginConfig.js
+++ b/cssCompiler/postcssPluginConfig.js
@@ -1,0 +1,19 @@
+const scssSyntax = require('postcss-scss')
+const autoprefixer = require('autoprefixer')
+const nodeSass = require('postcss-node-sass')
+const stylelint = require('stylelint')
+const reporter = require('postcss-reporter')
+
+const styleLintConfig = require('./styleLintConfig')
+
+const plugins = [
+  stylelint({ config: styleLintConfig }),
+  reporter({ clearReportedMessages: true }),
+  nodeSass({ includePaths: ['src/styles/'] }),
+  autoprefixer({
+    grid: 'autoplace',
+    browsers: ['> 1%'],
+  }),
+]
+
+module.exports = plugins


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the css compiler export a function that embed the POSTCSS config and plugins


## What is the new behavior?

we export separately the plugin list, in order to be used in any client task runner


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information