### PR TITLE
feat(plugin): add github release in gatsby graphql

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,6 +21,9 @@ module.exports = {
       },
     },
     {
+      resolve: 'gatsby-github-release'
+    },
+    {
       resolve: `gatsby-plugin-sass`,
       options: {
         includePaths: ['src/pages/**/*.scss'],

--- a/plugins/gatsby-github-release/gatsby-node.js
+++ b/plugins/gatsby-github-release/gatsby-node.js
@@ -1,0 +1,52 @@
+const fetch = require('node-fetch');
+
+exports.sourceNodes = async ({ actions, createNodeId, createContentDigest }) => {
+    const { createNode } = actions
+
+    const query = `
+        query {
+            repository(owner: "adeo", name: "design-system--styleguide") {
+            releases (first:100) {
+                totalCount
+                nodes{
+                    tagName
+                }
+            }
+        }
+    }
+    `
+
+    const response = await fetch('https://api.github.com/graphql', {
+        method: 'post',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer 66792a1df6e0dd6345b461535cb37b40961b4439'
+        },
+        body: JSON.stringify({ query })
+    })
+
+    const data = await response.json();
+
+    const tags = data.data.repository.releases.nodes;
+
+    tags.forEach(tag => {
+        const { tagName } = tag;
+
+        let nodeId = createNodeId(`github-release-${tagName}`);
+        let nodeData = Object.assign({}, { tagName }, {
+            'id': nodeId,
+            tagName,
+            'url': 'https://' + tagName.replace(/\./g, '') + '-dot-design-system-adeo.appspot.com',
+            'internal': {
+                'type': `GithubRelease`,
+                'content': JSON.stringify({ tagName }),
+                'contentDigest': createContentDigest({ tagName }),
+            }
+        });
+
+        createNode(nodeData);
+    })
+
+
+    return
+}

--- a/plugins/gatsby-github-release/package.json
+++ b/plugins/gatsby-github-release/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "gatsby-github-release",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "node-fetch": "^2.3.0"
+    }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #51 


## What is the new behavior?

In graphql Gatsby it's possible to see all release and deployement url 

Query exemple

`
query{
  allGithubRelease{
    edges{
      node{
        tagName,
        url
      }
    }
  }
}
`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information