### PR TITLE
feat(styleguide/version): create a select with versions and navigatio…

### DIFF
--- a/src/gatsby-components/Menu/Menu.js
+++ b/src/gatsby-components/Menu/Menu.js
@@ -17,7 +17,6 @@ const ShowChildrenButton = styled.button`
 
 const Container = styled.div`
   width: 220px;
-
 `
 
 const UlMenu = styled.ul`
@@ -111,7 +110,10 @@ export default class Menu extends PureComponent {
 
     return (
       <Container>
-        <MenuHeader siteTitle={siteTitle} />
+        <MenuHeader
+          siteTitle={siteTitle}
+          githubReleases={this.props.data.allGithubRelease.edges}
+        />
         <nav>{this.buildMenu(menuArray)}</nav>
       </Container>
     )

--- a/src/gatsby-components/Menu/MenuHeader.js
+++ b/src/gatsby-components/Menu/MenuHeader.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Link } from 'gatsby'
 
+import MenuVersionSelect from './MenuVersionSelect'
+
 const Header = styled.div`
   background: #f5f5f5;
   padding: 30px 15px;
@@ -12,13 +14,23 @@ const Header = styled.div`
   text-transform: uppercase;
 `
 
-const MenuHeader = ({ siteTitle }) => (
+const MenuHeader = ({ siteTitle, githubReleases }) => (
   <Header>
     <Link to="/">{siteTitle}</Link>
+    <MenuVersionSelect githubReleases={githubReleases} />
   </Header>
 )
+
 MenuHeader.propTypes = {
   siteTitle: PropTypes.string.isRequired,
+  githubReleases: PropTypes.arrayOf(
+    PropTypes.shape({
+      node: PropTypes.shape({
+        url: PropTypes.string.isRequired,
+        tagName: PropTypes.string.isRequired,
+      }).isRequired,
+    })
+  ).isRequired,
 }
 
 export default MenuHeader

--- a/src/gatsby-components/Menu/MenuVersionSelect.js
+++ b/src/gatsby-components/Menu/MenuVersionSelect.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+const LabelVersion = styled.label`
+  font-size: 0.5rem;
+  font-weight: normal;
+  line-height: 1;
+  letter-spacing: 0.1em;
+  margin-right: 5px;
+`
+
+class MenuVersionRelease extends Component {
+  handleChange = event => {
+    window.location.href = event.target.value
+  }
+
+  static propTypes = {
+    githubReleases: PropTypes.arrayOf(
+      PropTypes.shape({
+        node: PropTypes.shape({
+          url: PropTypes.string.isRequired,
+          tagName: PropTypes.string.isRequired,
+        }).isRequired,
+      })
+    ).isRequired,
+  }
+
+  render() {
+    const githubReleases = [...this.props.githubReleases].reverse()
+
+    return (
+      <div>
+        <LabelVersion>older tags:</LabelVersion>
+        <select onChange={this.handleChange}>
+          {githubReleases.map(release => (
+            <option key={release.node.tagName} value={release.node.url}>
+              {release.node.tagName}
+            </option>
+          ))}
+        </select>
+      </div>
+    )
+  }
+}
+
+export default MenuVersionRelease

--- a/src/gatsby-components/layout.js
+++ b/src/gatsby-components/layout.js
@@ -43,6 +43,7 @@ const Layout = ({ children }) => (
             data={{
               directoryTree: data.directoryTree,
               allMarkdownRemark: data.allMarkdownRemark,
+              allGithubRelease: data.allGithubRelease,
             }}
           />
         </MenuContainer>
@@ -63,6 +64,14 @@ const query = graphql`
     site {
       siteMetadata {
         title
+      }
+    }
+    allGithubRelease {
+      edges {
+        node {
+          tagName
+          url
+        }
       }
     }
     directoryTree(path: { eq: "src/pages" }) {


### PR DESCRIPTION
…n between them

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #51


## What is the new behavior?

create a select with all versions displayed. 
when selecting a version, you go on the related deployment. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information