### PR TITLE
feat(release): Add order published_at to github release

### DIFF
--- a/plugins/gatsby-github-release/gatsby-node.js
+++ b/plugins/gatsby-github-release/gatsby-node.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch');
+const fs = require('fs');
 
 exports.sourceNodes = async ({ actions, createNodeId, createContentDigest }) => {
     const { createNode } = actions
@@ -28,6 +29,8 @@ exports.sourceNodes = async ({ actions, createNodeId, createContentDigest }) => 
 
     const data = await response.json();
 
+    const version = JSON.parse(fs.readFileSync('registry/package.json'));
+
     const tags = data.data.repository.releases.nodes;
 
     tags.forEach(tag => {
@@ -37,6 +40,7 @@ exports.sourceNodes = async ({ actions, createNodeId, createContentDigest }) => 
         let nodeData = Object.assign({}, { tagName, publishedAt }, {
             'id': nodeId,
             tagName,
+            'isCurrent': tagName === `v${version.version}` ? true : false,
             publishedAt,
             'url': 'https://' + tagName.replace(/\./g, '') + '-dot-design-system-adeo.appspot.com',
             'internal': {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #109 


## What is the new behavior?

Add possibility to order by published at in query graphql  to release github.

```
query{
  allGithubRelease (sort: {fields: publishedAt, order: DESC}){
    edges{
      node{
        tagName,
        url
      }
    }
  }
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information