### PR TITLE
feat(styleguide/pattern): add possibility to override default font path

### DIFF
--- a/src/pages/typography/fontFamillies/code.md
+++ b/src/pages/typography/fontFamillies/code.md
@@ -23,6 +23,11 @@ Params :
 
 You can find the font-face into the `[registry path]/statics/fonts/` directory.
 
+## Overriding default path
+You can override the path using `$font-path` variable and define a new path depending on your project files.
+
+Declare the font-path variable in a file imported before `_all-settings.scss`, like `user.config.scss` created in your project.
+
 ## Font-faces formats :
 
 font-faces are imported with `woff` and `woff2` format.

--- a/src/styles/settings-tools/_s.fonts-faces.scss
+++ b/src/styles/settings-tools/_s.fonts-faces.scss
@@ -1,8 +1,15 @@
+// Default path
+$path : '/fonts';
+
+@if variable-exists(font-path) {
+  $path : $font-path;
+}
+
 @font-face {
   font-family: 'LeroyMerlin';
   src:
-    url('/fonts/LeroyMerlinSans-Web-Light.woff2') format('woff2'),
-    url('/fonts/LeroyMerlinSans-Web-Light.woff') format('woff');
+    url('#{$path}/LeroyMerlinSans-Web-Light.woff2') format('woff2'),
+    url('#{$path}/LeroyMerlinSans-Web-Light.woff') format('woff');
   font-weight: 300;
   font-style: normal;
 }
@@ -10,8 +17,8 @@
 @font-face {
   font-family: 'LeroyMerlin';
   src:
-    url('/fonts/LeroyMerlinSans-Web-Regular.woff2') format('woff2'),
-    url('/fonts/LeroyMerlinSans-Web-Regular.woff') format('woff');
+    url('#{$path}/LeroyMerlinSans-Web-Regular.woff2') format('woff2'),
+    url('#{$path}/LeroyMerlinSans-Web-Regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
 }
@@ -19,8 +26,8 @@
 @font-face {
   font-family: 'LeroyMerlin';
   src:
-    url('/fonts/LeroyMerlinSans-Web-SemiBold.woff2') format('woff2'),
-    url('/fonts/LeroyMerlinSans-Web-SemiBold.woff') format('woff');
+    url('#{$path}/LeroyMerlinSans-Web-SemiBold.woff2') format('woff2'),
+    url('#{$path}/LeroyMerlinSans-Web-SemiBold.woff') format('woff');
   font-weight: 600;
   font-style: normal;
 }
@@ -28,8 +35,8 @@
 @font-face {
   font-family: 'LeroyMerlin';
   src:
-    url('/fonts/LeroyMerlinSans-Web-LightItalic.woff2') format('woff2'),
-    url('/fonts/LeroyMerlinSans-Web-LightItalic.woff') format('woff');
+    url('#{$path}/LeroyMerlinSans-Web-LightItalic.woff2') format('woff2'),
+    url('#{$path}/LeroyMerlinSans-Web-LightItalic.woff') format('woff');
   font-weight: 300;
   font-style: italic;
 }
@@ -37,8 +44,8 @@
 @font-face {
   font-family: 'LeroyMerlin';
   src:
-    url('/fonts/LeroyMerlinSans-Web-Italic.woff2') format('woff2'),
-    url('/fonts/LeroyMerlinSans-Web-Italic.woff') format('woff');
+    url('#{$path}/LeroyMerlinSans-Web-Italic.woff2') format('woff2'),
+    url('#{$path}/LeroyMerlinSans-Web-Italic.woff') format('woff');
   font-weight: 400;
   font-style: italic;
 }
@@ -46,8 +53,8 @@
 @font-face {
   font-family: 'LeroyMerlin';
   src:
-    url('/fonts/LeroyMerlinSans-Web-SemiBoldItalic.woff2') format('woff2'),
-    url('/fonts/LeroyMerlinSans-Web-SemiBoldItalic.woff') format('woff');
+    url('#{$path}/LeroyMerlinSans-Web-SemiBoldItalic.woff2') format('woff2'),
+    url('#{$path}/LeroyMerlinSans-Web-SemiBoldItalic.woff') format('woff');
   font-weight: 600;
   font-style: italic;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Using the font file path : /fonts in @font-face.


## What is the new behavior?
Add possibility to override the default font path depending on the project files.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
