### PR TITLE
fix(build): not crash yarn develop when they are css error

### DIFF
--- a/plugins/gatsby-source-pattern/gatsby-node.js
+++ b/plugins/gatsby-source-pattern/gatsby-node.js
@@ -116,11 +116,11 @@ exports.sourceNodes = (
           cssCompiler(codes.scss, key, key.replace('.scss', '.css')).then(
             res => {
               codes.css = res.css
-              resolve(createNode(buildNodeData(nodeId, codes,  key.replace(/\\/g, '/'))))
+              resolve(createNode(buildNodeData(nodeId, codes, key.replace(/\\/g, '/'))))
             }
-          )
+          ).catch(error => resolve(createNode(buildNodeData(nodeId, { html: error, css: '' }, key.replace(/\\/g, '/')))))
         } else {
-          resolve(createNode(buildNodeData(nodeId, codes,  key.replace(/\\/g, '/'))))
+          resolve(createNode(buildNodeData(nodeId, codes, key.replace(/\\/g, '/'))))
         }
       })
     })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?


Issue Number: #160 


## What is the new behavior?

When CssCompiler have error on compiling css, it sending a reject promise. We need to catch this promise un gatsby plugin to send directly error of compiling in html node.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information