### PR TITLE
feat(build): add watch to plugin directory tree

### DIFF
--- a/plugins/gatsby-source-directory-tree/gatsby-node.js
+++ b/plugins/gatsby-source-directory-tree/gatsby-node.js
@@ -1,59 +1,188 @@
 const dirTree = require('directory-tree');
+const chokidar = require(`chokidar`)
+const fs = require(`fs`)
+const { Machine } = require(`xstate`)
 
 
-exports.sourceNodes = ({ actions, createNodeId, createContentDigest, createParentChildLink }, configOptions) => {
+const createFSMachine = () =>
+  Machine({
+    key: `emitFSEvents`,
+    parallel: true,
+    strict: true,
+    states: {
+      CHOKIDAR: {
+        initial: `CHOKIDAR_NOT_READY`,
+        states: {
+          CHOKIDAR_NOT_READY: {
+            on: {
+              CHOKIDAR_READY: `CHOKIDAR_WATCHING`,
+              BOOTSTRAP_FINISHED: `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`,
+            },
+          },
+          CHOKIDAR_WATCHING: {
+            on: {
+              BOOTSTRAP_FINISHED: `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`,
+              CHOKIDAR_READY: `CHOKIDAR_WATCHING`,
+            },
+          },
+          CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED: {
+            on: {
+              CHOKIDAR_READY: `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`,
+            },
+          },
+        },
+      },
+    },
+  })
 
-    const { createNode } = actions
+exports.sourceNodes = ({ actions, createNodeId, createContentDigest, reporter, emitter }, configOptions) => {
+  const fsMachine = createFSMachine()
+  let currentState = fsMachine.initialState
 
-    // Gatsby adds a configOption that's not needed for this plugin, delete it
-    delete configOptions.plugins
-    const tree = dirTree(configOptions.path);
+  emitter.on(`BOOTSTRAP_FINISHED`, () => {
+    currentState = fsMachine.transition(
+      currentState.value,
+      `BOOTSTRAP_FINISHED`
+    )
+  })
+
+  const watcher = chokidar.watch(
+    [configOptions.path],
+    {}
+  )
 
 
-    const processDirectoryTree = (tree, parentNode) => {
+
+  // Gatsby adds a configOption that's not needed for this plugin, delete it
+  delete configOptions.plugins
+
+  const buildSourceDirectoryTree = () =>
+    new Promise((resolve, reject) => {
+      const { createNode } = actions
+      const tree = dirTree(configOptions.path);
+      const processDirectoryTree = (tree, parentNode) => {
         const nodeId = createNodeId(`directory-tree-${tree.path}`)
 
         const { path, name, size, type } = tree;
         let childrenNode = [];
 
         let nodeData = Object.assign({}, { path, name, size, type }, {
-            'id': nodeId,
-            parentNode,
-            path,
-            name,
-            size,
-            type,
-            childrenNode,
-            'internal': {
-                'type': `DirectoryTree`,
-                'content': JSON.stringify({ path, name, size, type }),
-                'contentDigest': createContentDigest({ path, name, size, type }),
-            }
+          'id': nodeId,
+          parentNode,
+          path,
+          name,
+          size,
+          type,
+          childrenNode,
+          'internal': {
+            'type': `DirectoryTree`,
+            'content': JSON.stringify({ path, name, size, type }),
+            'contentDigest': createContentDigest({ path, name, size, type }),
+          }
         });
 
         if (tree.children) {
-            childrenNode = processChildren(tree.children, nodeData);
-            nodeData.childrenNode = childrenNode;
+          childrenNode = processChildren(tree.children, nodeData);
+          nodeData.childrenNode = childrenNode;
         }
 
         return nodeData;
-    }
+      }
 
-    const processChildren = (children, parentNode) => {
+      const processChildren = (children, parentNode) => {
         let childrenNodes = [];
         children.forEach(element => {
-            const nodeData = processDirectoryTree(element, parentNode);
-            createNode(nodeData);
+          const nodeData = processDirectoryTree(element, parentNode);
+          createNode(nodeData);
 
-            const { path, name, size, type, id, childrenNode } = nodeData;
-            childrenNodes.push({ path, name, size, type, id, childrenNode });
+          const { path, name, size, type, id, childrenNode } = nodeData;
+          childrenNodes.push({ path, name, size, type, id, childrenNode });
         });
 
         return childrenNodes;
+      }
+
+      const nodeData = processDirectoryTree(tree);
+
+      resolve(createNode(nodeData));
+    });
+
+  // For every path that is reported before the 'ready' event, we throw them
+  // into a queue and then flush the queue when 'ready' event arrives.
+  // After 'ready', we handle the 'add' event without putting it into a queue.
+  let pathQueue = []
+  const flushPathQueue = () => {
+    let queue = pathQueue.slice()
+    pathQueue = []
+    return Promise.all(queue.map(buildSourceDirectoryTree))
+  }
+
+  watcher.on(`add`, path => {
+    if (currentState.value.CHOKIDAR !== `CHOKIDAR_NOT_READY`) {
+      if (
+        currentState.value.CHOKIDAR === `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`
+      ) {
+        reporter.info(`added pattern file at ${path}`)
+      }
+      buildSourceDirectoryTree().catch(err => reporter.error(err))
+    } else {
+      pathQueue.push(path)
     }
+  })
 
-    const nodeData = processDirectoryTree(tree);
+  watcher.on(`change`, path => {
+    if (
+      currentState.value.CHOKIDAR === `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`
+    ) {
+      reporter.info(`changed pattern file at ${path}`)
+    }
+    buildSourceDirectoryTree().catch(err => reporter.error(err))
+  })
 
-    createNode(nodeData);
+  watcher.on(`unlink`, path => {
+    if (currentState.value.CHOKIDAR !== `CHOKIDAR_NOT_READY`) {
+      if (
+        currentState.value.CHOKIDAR === `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`
+      ) {
+        reporter.info(`delete file at ${path}`)
+      }
+      buildSourceDirectoryTree().catch(err => reporter.error(err))
+    } else {
+      pathQueue.push(path)
+    }
+  })
+
+  watcher.on(`addDir`, path => {
+    if (currentState.value.CHOKIDAR !== `CHOKIDAR_NOT_READY`) {
+      if (
+        currentState.value.CHOKIDAR === `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`
+      ) {
+        reporter.info(`added directory at ${path}`)
+      }
+      buildSourceDirectoryTree().catch(err => reporter.error(err))
+    } else {
+      pathQueue.push(path)
+    }
+  })
+
+  watcher.on(`unlinkDir`, path => {
+    if (currentState.value.CHOKIDAR !== `CHOKIDAR_NOT_READY`) {
+      if (
+        currentState.value.CHOKIDAR === `CHOKIDAR_WATCHING_BOOTSTRAP_FINISHED`
+      ) {
+        reporter.info(`delete dir at ${path}`)
+      }
+      buildSourceDirectoryTree().catch(err => reporter.error(err))
+    } else {
+      pathQueue.push(path)
+    }
+  })
+
+  return new Promise((resolve, reject) => {
+    watcher.on(`ready`, () => {
+      currentState = fsMachine.transition(currentState.value, `CHOKIDAR_READY`)
+      flushPathQueue().then(resolve, reject)
+    })
+  })
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #162 


## What is the new behavior?

Now we have watching for gatsby plugin directory tree

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information