### PR TITLE
fix(version nb): use lerna.json instead of package.json to get version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cache
 node_modules
 yarn-error.log
+lerna-debug.log
 
 # Build directory
 /public

--- a/packages/gatsby-github-release/gatsby-node.js
+++ b/packages/gatsby-github-release/gatsby-node.js
@@ -34,7 +34,7 @@ exports.sourceNodes = async ({
   const data = await response.json()
 
   const version = JSON.parse(
-    fs.readFileSync(path.join(process.cwd(), 'package.json'))
+    fs.readFileSync(path.join(process.cwd(), 'lerna.json'))
   )
 
   const tags = data.data.repository.releases.nodes


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

the version displayed was v0.0.0

## What is the new behavior?

we compare the version number with the Lerna.json file instead of the package.json file