### PR TITLE
perf(styleguide/previews): make the previews scss build fast

### DIFF
--- a/packages/css-dev-tools/css-pipeline.js
+++ b/packages/css-dev-tools/css-pipeline.js
@@ -6,6 +6,8 @@ const postcssWithConfig = postcss(postCssPluginConfig)
 
 const cssCompiler = (scss, pathFrom, pathTo) =>
   new Promise((resolve, reject) => {
+    console.log('processing css: ' + pathFrom)
+
     postcssWithConfig
       .process(scss, {
         from: pathFrom,

--- a/packages/gatsby-source-preview/gatsby-node.js
+++ b/packages/gatsby-source-preview/gatsby-node.js
@@ -62,6 +62,10 @@ exports.sourceNodes = (
 
   const buildPreviews = () =>
     new Promise((resolve, reject) => {
+      console.log('-----------------------------')
+      console.log('--- building all previews ---')
+      console.log('-----------------------------')
+
       const { createNode } = actions
       const tree = dirTree(configOptions.path)
 
@@ -145,10 +149,9 @@ exports.sourceNodes = (
   // into a queue and then flush the queue when 'ready' event arrives.
   // After 'ready', we handle the 'add' event without putting it into a queue.
   let pathQueue = []
+
   const flushPathQueue = () => {
-    let queue = pathQueue.slice()
-    pathQueue = []
-    return Promise.all(queue.map(buildPreviews))
+    buildPreviews()
   }
 
   watcher.on(`add`, path => {
@@ -157,11 +160,9 @@ exports.sourceNodes = (
         currentState.value.CHOKIDAR ===
         `CHOKIDAR_PREVIEW_WATCHING_BOOTSTRAP_FINISHED`
       ) {
+        buildPreviews().catch(err => reporter.error(err))
         reporter.info(`added PREVIEW file at ${path}`)
       }
-      buildPreviews().catch(err => reporter.error(err))
-    } else {
-      pathQueue.push(path)
     }
   })
 
@@ -170,9 +171,9 @@ exports.sourceNodes = (
       currentState.value.CHOKIDAR ===
       `CHOKIDAR_PREVIEW_WATCHING_BOOTSTRAP_FINISHED`
     ) {
+      buildPreviews().catch(err => reporter.error(err))
       reporter.info(`changed PREVIEW file at ${path}`)
     }
-    buildPreviews().catch(err => reporter.error(err))
   })
 
   watcher.on(`unlink`, path => {
@@ -196,11 +197,9 @@ exports.sourceNodes = (
         currentState.value.CHOKIDAR ===
         `CHOKIDAR_PREVIEW_WATCHING_BOOTSTRAP_FINISHED`
       ) {
+        buildPreviews().catch(err => reporter.error(err))
         reporter.info(`added directory at ${path}`)
       }
-      buildPreviews().catch(err => reporter.error(err))
-    } else {
-      pathQueue.push(path)
     }
   })
 
@@ -223,8 +222,7 @@ exports.sourceNodes = (
         currentState.value,
         `CHOKIDAR_PREVIEW_READY`
       )
-      pathQueue.push('test')
-      flushPathQueue().then(resolve, reject)
+      buildPreviews().then(resolve, reject)
     })
   })
 }

--- a/packages/gatsby-theme-styleguide/gatsby-config.js
+++ b/packages/gatsby-theme-styleguide/gatsby-config.js
@@ -2,8 +2,6 @@ const path = require('path')
 
 module.exports = {
   plugins: [
-    'gatsby-plugin-react-helmet',
-    'gatsby-plugin-styled-components',
     {
       resolve: '@gardencss/gatsby-source-preview',
       options: {
@@ -11,6 +9,8 @@ module.exports = {
         stylesPath: 'packages/styles',
       },
     },
+    'gatsby-plugin-react-helmet',
+    'gatsby-plugin-styled-components',
     {
       resolve: '@gardencss/gatsby-source-directory-tree',
       options: {
@@ -40,7 +40,7 @@ module.exports = {
       options: {
         name: `src`,
         path: path.join('src'),
-        ignore: [`**/Previews/*.*`], // ignore files starting with a dot
+        ignore: [`**/Previews/*.*`, `*.previews.*`], // ignore files starting with a dot
       },
     },
     'gatsby-transformer-json',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
make the scss build for the previews run only once (it was builded many times, making the build verrrrry slow)