### PR TITLE
fix(styleguide/preview): watch changes only in preview files

### DIFF
--- a/packages/css-dev-tools/css-pipeline.js
+++ b/packages/css-dev-tools/css-pipeline.js
@@ -6,8 +6,6 @@ const postcssWithConfig = postcss(postCssPluginConfig)
 
 const cssCompiler = (scss, pathFrom, pathTo) =>
   new Promise((resolve, reject) => {
-    console.log('processing css: ' + pathFrom)
-
     postcssWithConfig
       .process(scss, {
         from: pathFrom,

--- a/packages/gatsby-source-preview/gatsby-node.js
+++ b/packages/gatsby-source-preview/gatsby-node.js
@@ -53,7 +53,7 @@ exports.sourceNodes = (
   })
 
   const watcher = chokidar.watch(
-    [configOptions.path, configOptions.stylesPath],
+    [configOptions.previewsFiles, configOptions.stylesPath],
     {}
   )
 
@@ -67,7 +67,7 @@ exports.sourceNodes = (
       console.log('-----------------------------')
 
       const { createNode } = actions
-      const tree = dirTree(configOptions.path)
+      const tree = dirTree(configOptions.rootPath)
 
       let previews = {}
 
@@ -119,6 +119,7 @@ exports.sourceNodes = (
         if (codes.scss && codes.scss !== '') {
           cssCompiler(codes.scss, key, key.replace('.scss', '.css'))
             .then(res => {
+              reporter.success(`preview builded: ${key}`)
               codes.css = res.css
               resolve(
                 createNode(

--- a/packages/gatsby-theme-styleguide/gatsby-config.js
+++ b/packages/gatsby-theme-styleguide/gatsby-config.js
@@ -5,8 +5,9 @@ module.exports = {
     {
       resolve: '@gardencss/gatsby-source-preview',
       options: {
-        path: 'src/pages',
-        stylesPath: 'packages/styles',
+        previewsFiles: 'src/pages/**/*.preview.*',
+        rootPath: 'src/pages',
+        stylesPath: 'packages/styles/**/*.scss',
       },
     },
     'gatsby-plugin-react-helmet',


### PR DESCRIPTION
and thus avoid rebuilding all previews when a scss file is changed in pages

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: DS-28

Watch changes only in `*.preview.*` files before rebuilding previews.