### PR TITLE
fix(documentation): wrong import for typography and components

### DIFF
--- a/src/pages/Foundations/Typography/BodyStyles/code.md
+++ b/src/pages/Foundations/Typography/BodyStyles/code.md
@@ -11,7 +11,7 @@ You can import all base typography scss files by importing the `_a.all-base-typo
 
 ```css
 @import 'settings-tools/_all-settings';
-@import 'atoms/_a.all-base-typography';
+@import 'typography/_t.all-base-typography';
 ```
 
 ## Body classes

--- a/src/pages/Foundations/Typography/HeadingStyles/code.md
+++ b/src/pages/Foundations/Typography/HeadingStyles/code.md
@@ -11,7 +11,7 @@ You can import all base typography scss files by importing the `_a.all-base-typo
 
 ```css
 @import 'settings-tools/_all-settings';
-@import 'atoms/_a.all-base-typography';
+@import 'typography/_t.all-base-typography';
 ```
 
 ## Heading classes

--- a/src/pages/Foundations/Typography/HeroStyles/code.md
+++ b/src/pages/Foundations/Typography/HeroStyles/code.md
@@ -11,7 +11,7 @@ You can import all base typography scss files by importing the `_a.all-base-typo
 
 ```css
 @import 'settings-tools/_all-settings';
-@import 'atoms/_a.all-base-typography';
+@import 'typography/_t.all-base-typography';
 ```
 
 ## Hero classes

--- a/src/pages/GetStarted/Developers/npmScriptTutorial/index.md
+++ b/src/pages/GetStarted/Developers/npmScriptTutorial/index.md
@@ -291,8 +291,7 @@ your browser should now look like this :
 
 // your components
 @import '../node_modules/@mozaic-ds/styles/layout/_l.grid';
-@import '../node_modules/@mozaic-ds/styles/atoms/_a.button';
-@import '../node_modules/@mozaic-ds/styles/molecule/_m.button';
+@import '../node_modules/@mozaic-ds/styles/components/_c.button';
 ```
 
 note that you need to follow the ITCSS/ADS [import order](https://gael-boyenval.gitbook.io/atomic-design-css-architecture-with-itcss-bem-sass/principles/unifying-itcss-with-ads#summarize-the-new-architecture)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
 Old import using atomic structure in documentation


## What is the new behavior?
New import with typography and component

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
