### PR TITLE
fix(pattern/grids): fix typo in flexy class name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log
 .DS_Store
 .vscode
 /.idea/
+*.iml
 package-lock.json
 # static/icons/
 

--- a/packages/styles/layouts/_l.flexy.scss
+++ b/packages/styles/layouts/_l.flexy.scss
@@ -9,7 +9,7 @@
     }
   }
 
-  &--space-aroud {
+  &--space-around {
     @include modify-from-screens($major-screens) {
       justify-content: space-around;
     }

--- a/src/pages/Foundations/Layout/Grid/previews/flexyCentered.preview.html
+++ b/src/pages/Foundations/Layout/Grid/previews/flexyCentered.preview.html
@@ -1,4 +1,4 @@
-<div class="ml-flexy ml-flexy--space-aroud ml-flexy--items-center example">
+<div class="ml-flexy ml-flexy--space-around ml-flexy--items-center example">
   <div class="example__item">
     Hello<br />
     i'm centered


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/adeo/design-system--styleguide/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

This PR fixes a typo in a class name.


## What is the current behavior?
The `ml-flexy--space-around` is not working because of a typo in the class name (`ml-flexy--space-aroud`).

Issue Number: N/A


## What is the new behavior?
The typo fix allows to correctly apply the space around behaviour to the flexy element.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information