### PR TITLE
fix(website): fixing some typos

### DIFF
--- a/src/docs/Components/index.mdx
+++ b/src/docs/Components/index.mdx
@@ -3,4 +3,4 @@ title: 'Components'
 order: 3
 ---
 
-Comming soon !!
+Coming soon !!

--- a/src/docs/Contributing/Prerequisite/GitConventions/index.mdx
+++ b/src/docs/Contributing/Prerequisite/GitConventions/index.mdx
@@ -5,7 +5,7 @@ order: 5
 
 ## Branch names
 
-Each branch name consists of a `type` that matches the main commit one, an optional issue `id` comming from a JIRA ticket or a Github issue and a `description`.
+Each branch name consists of a `type` that matches the main commit one, an optional issue `id` coming from a JIRA ticket or a Github issue and a `description`.
 
 ```shell
 git checkout -b type-id-description
@@ -28,7 +28,7 @@ Each commit message consists of a `type`, a `scope` and a `description`.
 feat(component/button): add a warning color theme
 ```
 
-> Commit message's lines **cannot be longer than 140 characters**!  
+> Commit message's lines **cannot be longer than 140 characters**!
 > This leads to **messages that are easier to read** when looking through the project history.
 
 We are **automating the releases version numbers (SEMVER) and the generation of the changelogs files by parsing the commit messages**.
@@ -98,7 +98,7 @@ In that case it is the right call to duplicate the class, mixin or function to s
 
 ## Pull requests
 
-The pull request titles follows the same rules as the commit message and consist of a `type`, an optional `scope` and a `description`. You have to use the same convention described in the commit part.  
+The pull request titles follows the same rules as the commit message and consist of a `type`, an optional `scope` and a `description`. You have to use the same convention described in the commit part.
 **Most of the time your PR title will be the same as the commit message**.
 
 #### Labels


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/contributing)

- [X] Yes
- [ ] No

## Does this PR introduce a breaking change?

read [What is a breaking change ?](/Contributing/GitConventions/)

- [ ] Yes
- [X] No

## Describe the changes

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We had some "comming soon" typos on the styleguide

Github issue number or Jira issue URL: [MZC-177](https://design-system-adeo.atlassian.net/browse/MZC-177?atlOrigin=eyJpIjoiNWUwMjNkZDEwODYxNDgxNzhlZGMyZmU1OGQzYzkxMTQiLCJwIjoiaiJ9)

## Other informations