### PR TITLE
fix(onboard/side effects): fix side effects after reorganize contrib pages

### DIFF
--- a/packages/gatsby-theme-styleguide/src/gatsby-components/TableOfContents/tableofcontents.scss
+++ b/packages/gatsby-theme-styleguide/src/gatsby-components/TableOfContents/tableofcontents.scss
@@ -12,10 +12,11 @@
     padding-left: 1.5rem;
     padding-top: 1rem;
     padding-bottom: 1rem;
-    margin-top: 1rem;
     top: 0;
     position: sticky;
     border-left: solid 1px #f5f5f5;
+    max-height: 90vh;
+    overflow-y: auto;
   }
 
   &__title {

--- a/src/docs/Contributing/Prerequisite/CSSConventions/index.mdx
+++ b/src/docs/Contributing/Prerequisite/CSSConventions/index.mdx
@@ -527,7 +527,7 @@ Add also **the version in witch the support is supposed to be dropped**.
 ## Tokens comment
 
 Design tokens are theming/styling constants defined in a JSON file.  
-For more information about tokens, please read the ["Design Tokens" chapter](http://mozaic.adeo.cloud/GetStarted/Developers/whatsincluded/#design-tokens-) in the **Getting started** section.
+For more information about tokens, please read the ["Design Tokens" chapter](http://mozaic.adeo.cloud/GetStarted/Developers/whatsincluded/#design-tokens) in the **Getting started** section.
 
 It is possible to add a comment to a token property, simply by adding a new `key/value` pair to the JSON file.  
 The key must be named `comment` and the value contains the comment you want to write.

--- a/src/docs/Contributing/Prerequisite/InstallForDev/index.mdx
+++ b/src/docs/Contributing/Prerequisite/InstallForDev/index.mdx
@@ -24,7 +24,7 @@ The project Use a monorepo architecture using [lerna](https://github.com/lerna/l
 Lerna help us to manage the distribution and the versionning of multiple packages into the same repository.  
 It also create symlink between the individual packages nodes_modules so they can be used in one another as npm dependencies.
 
-When releasing the design system, lerna will automaticaly generate changelogs for the global/parent repo, as well as for the individual packages and select a version number based on the commit syntax. It's why it is very important that you follow the [contributing guidelines](/Contributing/GitConventions/).
+When releasing the design system, lerna will automaticaly generate changelogs for the global/parent repo, as well as for the individual packages and select a version number based on the commit syntax. It's why it is very important that you follow the [contributing guidelines](/Contributing/Prerequisite/GitConventions/).
 
 please [read the docs](https://github.com/lerna/lerna/) to learn more about it.
 

--- a/src/docs/Contributing/ReportBug/index.mdx
+++ b/src/docs/Contributing/ReportBug/index.mdx
@@ -20,7 +20,7 @@ Connect to the slack **#mozaic-support** channel on [Adeo’s global Slack accou
 
 You can submit a bug fix, but note the bug could be potentially being adressed or trickier than expected to fix. So we recommend that you report it first so the team can give you a quick feedback.
 
-If you are confident about the bug fix, please read our [submit a bug fix](/Contributing/SubmitBugFix/) documentation first.
+If you are confident about the bug fix, please read our [submit a bug fix](/Contributing/SubmitChanges/SubmitBugFix/) documentation first.
 
 ## What we call a bug
 

--- a/src/docs/Contributing/SubmitChanges/AddNewPattern/index.mdx
+++ b/src/docs/Contributing/SubmitChanges/AddNewPattern/index.mdx
@@ -3,9 +3,11 @@ title: 'Add a new pattern'
 order: 6
 ---
 
+> If you are a designer you also need to read the [Definition of Done for Sketch symbols contribution](/Contributing/SubmitChanges/DesignToolsConventions/#sketch) page
+
 MOZAIC being an evolving and collaborative tool, you are free to propose new patterns.
 
-However, here are two recommendations to take into account before you start:
+However, here are some recommendations to take into account before you start:
 
 ## 1. Make sure that the pattern doesn't exist
 
@@ -38,4 +40,4 @@ If you want to discuss about a pattern before submitting it :
 
 ## 4. Let's go
 
-After checking all these points, you can now add your new pattern: [Submit a new pattern](http://mozaic.adeo.cloud/Contributing/NewPattern/SubmitNewPattern/).
+After checking all these points, you can now add your new pattern: [Submit a new pattern](/Contributing/SubmitChanges/SubmitNewPattern/).

--- a/src/docs/Contributing/SubmitChanges/DesignToolsConventions/index.mdx
+++ b/src/docs/Contributing/SubmitChanges/DesignToolsConventions/index.mdx
@@ -69,7 +69,7 @@ You can download the [designer kit](https://github.com/adeo/design-system--style
 
 > From a designer point of view, Mozaic is based on Sketch and Abstract. Abstract is a versioning software for design files and allows teams to collaborate with a modern workflow. Like a developer does in GitHub, you need to ask for a review before merging your branches. We wrote some rules to follow before clicking **_Request Review_** on Abstract.
 
-## 1. The symbols have been created following the [definition of Done for symbols](/Contributing/Designers/definitionOfDoneSymbols/index.md) page.
+## 1. The symbols have been created following the [definition of Done for symbols](/Contributing/SubmitChanges/DesignToolsConventions/#sketch) page.
 
 We wrote some definition of done rules when you create some symbols in Sketch. Please read these instructions before submitting a review on Abstract. It will make the process way easier for us and we thank you for that 🤘.
 

--- a/src/docs/Contributing/SubmitChanges/PatternEnhancement/index.mdx
+++ b/src/docs/Contributing/SubmitChanges/PatternEnhancement/index.mdx
@@ -37,6 +37,6 @@ Another method _(recommended)_ is to create an **Issue** in the [MOZAIC project 
 
 If you have the opportunity, you can directly submit the improvement you want to implement by creating a Pull Request.
 
-For more details, please read our [documentation about Pull Request](http://mozaic.adeo.cloud/Contributing/GitConventions/#pull-request).
+For more details, please read our [documentation about Pull Request](/Contributing/Prerequisite/GitConventions/#pull-requests).
 
 Note that a pattern enhancement require only the core team validation to be merged.

--- a/src/docs/Contributing/SubmitChanges/SubmitBugFix/index.mdx
+++ b/src/docs/Contributing/SubmitChanges/SubmitBugFix/index.mdx
@@ -15,8 +15,8 @@ If you have the opportunity, we recommend you to submit a **Pull Request** conta
 
 ### We will check that the PR…
 
-- The PR title and commits messages follows [our conventions](http://mozaic.adeo.cloud/Contributing/GitConventions)
-- If it is related to CSS, that the PR follow [our css conventions](http://mozaic.adeo.cloud/Contributing/CSSConventions/)
+- The PR title and commits messages follows [our conventions](/Contributing/Prerequisite/GitConventions/)
+- If it is related to CSS, that the PR follow [our css conventions](/Contributing/Prerequisite/CSSConventions/)
 - The docs are updated if necessary
 - That there is no breaking changes
 - That the fix do not have undesired sides effects
@@ -24,7 +24,7 @@ If you have the opportunity, we recommend you to submit a **Pull Request** conta
 ## Submit a fix on a sketch library
 
 If the bug fix is related to a sketch library :
-Please follow the [designer contribution guidelines](Contributing/Designers/)
+Please follow the [designer contribution guidelines](/Contributing/SubmitChanges/DesignToolsConventions/)
 
 ## Merge criterias
 

--- a/src/docs/Contributing/SubmitChanges/SubmitNewPattern/index.mdx
+++ b/src/docs/Contributing/SubmitChanges/SubmitNewPattern/index.mdx
@@ -3,7 +3,7 @@ title: 'Submit a new pattern'
 order: 10
 ---
 
-> If you are a designer you also need to read the [Definition of Done for Sketch symbols contribution](http://mozaic.adeo.cloud/Contributing/Designers/definitionOfDoneSymbols/) page
+> If you are a designer you also need to read the [Definition of Done for Sketch symbols contribution](/Contributing/SubmitChanges/DesignToolsConventions/#sketch) page
 
 <br/>
 
@@ -65,6 +65,6 @@ Your folder may also contain an implementation of the pattern's scss/js code wit
 
 Once you have finished working on your pattern, it is time to push your branch and create a Pull Request associated with your work.
 
-Please respect the [Git conventions](http://mozaic.adeo.cloud/Contributing/GitConventions/) that we defined before pushing your work.
+Please respect the [Git conventions](/Contributing/Prerequisite/GitConventions/) that we defined before pushing your work.
 
-You will also find in the [Git conventions](http://mozaic.adeo.cloud/Contributing/GitConventions/) page, the recommended method to make your Pull Request.
+You will also find in the [Git conventions](/Contributing/Prerequisite/GitConventions/#pull-requests) page, the recommended method to make your Pull Request.


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/contributing)

- [x] Yes
- [ ] No

## Does this PR introduce a breaking change?

read [What is a breaking change ?](/Contributing/GitConventions/)

- [ ] Yes
- [x] No

## Describe the changes

Fixes edge effects that appeared after refactoring Contributing pages

Github issue number or Jira issue URL: **176**

## Other informations
