### PR TITLE
fix(patterns/margins and paddings): fix bug where units where rendere…

### DIFF
--- a/packages/styles/settings-tools/_s.spaces.scss
+++ b/packages/styles/settings-tools/_s.spaces.scss
@@ -2,23 +2,23 @@
 // do not use them anywhere,
 // it is used internally and may change
 $sizes: (
-  025: $mu025,
-  050: $mu050,
-  075: $mu075,
-  100: $mu100,
-  125: $mu125,
-  150: $mu150,
-  200: $mu200,
-  250: $mu250,
-  300: $mu300,
-  350: $mu350,
-  400: $mu400,
-  500: $mu500,
-  600: $mu600,
-  700: $mu700,
-  800: $mu800,
-  900: $mu900,
-  1000: $mu1000,
+  '025': $mu025,
+  '050': $mu050,
+  '075': $mu075,
+  '100': $mu100,
+  '125': $mu125,
+  '150': $mu150,
+  '200': $mu200,
+  '250': $mu250,
+  '300': $mu300,
+  '350': $mu350,
+  '400': $mu400,
+  '500': $mu500,
+  '600': $mu600,
+  '700': $mu700,
+  '800': $mu800,
+  '900': $mu900,
+  '1000': $mu1000,
 );
 
 // top, right, left, bottom, all
@@ -27,7 +27,7 @@ $sides: (
   'r': 'right',
   'l': 'left',
   'b': 'bottom',
-  'all' : 'all'
+  'all': 'all',
 );
 
 $props: (
@@ -36,13 +36,9 @@ $props: (
 );
 
 @mixin make-space-util($prop, $side, $size) {
-  @if ($side == "all") {
+  @if ($side == 'all') {
     .mu-#{$prop}-#{$size} {
-      #{map-get($props, $prop)}:
-        #{map-get(
-          $sizes,
-          $size
-        )} !important;
+      #{map-get($props, $prop)}: #{map-get($sizes, $size)} !important;
     }
   }
 

--- a/src/docs/Foundations/Layout/MarginAndPaddings/code.mdx
+++ b/src/docs/Foundations/Layout/MarginAndPaddings/code.mdx
@@ -12,6 +12,8 @@ You can add to your bundle the margins or paggings utility classes like so :
 @import 'utilities/_u.padding.scss';
 ```
 
+<Preview path="margins" />
+
 ```html
 <div class="mu-mb-100">
   I will have a 1mu (16px) margin bottom
@@ -48,8 +50,8 @@ You can implement your own margins or paggings utility using the space mixin :
 */
 ```
 
-<br /><br />
-
+<br />
+<br />
 <HintItem dont>
   Do not use margin and padding utilities inside components
 </HintItem>
@@ -62,7 +64,6 @@ You can implement your own margins or paggings utility using the space mixin :
 ```
 
 <br />
-
 <HintItem>Use utilities to manage space between components</HintItem>
 
 ```html
@@ -74,7 +75,6 @@ You can implement your own margins or paggings utility using the space mixin :
 ```
 
 <br />
-
 <HintItem>
   Use margins and padding using variables or functions to define inner spaces
 </HintItem>

--- a/src/docs/Foundations/Layout/MarginAndPaddings/previews/margins.preview.html
+++ b/src/docs/Foundations/Layout/MarginAndPaddings/previews/margins.preview.html
@@ -1,0 +1,8 @@
+<div class="example mu-pb-025 mu-mt-250">
+  <div class="example__item mu-mb-075 mu-pb-200 mu-pt-075 mu-ml-350">
+    margin-bottom of 0.75mu <br />
+    margin-left of 3.5mu <br />
+    padding-top of 0.75mu <br />
+    padding-bottom of 2mu <br />
+  </div>
+</div>

--- a/src/docs/Foundations/Layout/MarginAndPaddings/previews/margins.preview.scss
+++ b/src/docs/Foundations/Layout/MarginAndPaddings/previews/margins.preview.scss
@@ -1,0 +1,14 @@
+@import 'settings-tools/_all-settings';
+
+@include import-font-families();
+
+@import 'utilities/_u.margin';
+@import 'utilities/_u.padding';
+
+.example {
+  background-color: $color-primary-02-200;
+
+  &__item {
+    background-color: $color-primary-01-200;
+  }
+}


### PR DESCRIPTION
…d as numbers in classes names resulting in truncated leading 0

## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a breaking change?

read [What is a breaking change ?](https://mozaic.adeo.cloud/Contributing/Prerequisite/GitConventions/#breaking-changes-)

- [ ] Yes
- [x] No

## Describe the changes

Fix a bug where `.mu-pb-075` and such classes were rendered as `.mu-pb-75`

## Other informations
