### PR TITLE
fix(website/spacings): wrong var names - Fixes #474

### DIFF
--- a/src/docs/Foundations/Layout/MarginAndPaddings/code.mdx
+++ b/src/docs/Foundations/Layout/MarginAndPaddings/code.mdx
@@ -44,7 +44,7 @@ You can implement your own margins or paggings utility using the space mixin :
 
 @include make-space-util(m, t, 075);
 /*
-.mu-mt-075 { 
+.mu-mt-075 {
     margin-top: 12px !important;
 }
 */
@@ -86,7 +86,7 @@ You can implement your own margins or paggings utility using the space mixin :
   /* ... list styles */
 
   &__item {
-    margin-bottom: $mu-025;
+    margin-bottom: $mu025;
   }
 }
 ```
@@ -110,7 +110,7 @@ To remove border sizes from vertical padding, as borders are expressed in `px` a
 
 .exemple {
   border: solid 1px block;
-  line-height: $mu-150;
-  padding: calc($mu-025 - 1px) $mu-025;
+  line-height: $mu150;
+  padding: calc($mu025 - 1px) $mu025;
 }
 ```


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a breaking change?

read [What is a breaking change ?](https://mozaic.adeo.cloud/Contributing/Prerequisite/GitConventions/#breaking-changes-)

- [ ] Yes
- [x] No

## Describe the changes

**Wrong var names for spacings**

Github issue number or Jira issue URL: https://github.com/adeo/mozaic-design-system/issues/474

## Other informations
