### PR TITLE
fix(tools/stylelint): quickfix stylelint for vuejs - disable max-empt…

### DIFF
--- a/packages/css-dev-tools/styleLintConfig.js
+++ b/packages/css-dev-tools/styleLintConfig.js
@@ -36,6 +36,7 @@ module.exports = {
   plugins: ['@mozaic-ds/stylelint-plugin-mozaic', 'stylelint-scss'],
   rules: {
     'at-rule-no-unknown': null,
+    'max-empty-lines': null,
     'plugin/mozaic-bem-pattern': [pickConfig()],
   },
 }


### PR DESCRIPTION
…y-lines rule

## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a breaking change?

read [What is a breaking change ?](https://mozaic.adeo.cloud/Contributing/Prerequisite/GitConventions/#breaking-changes-)

- [ ] Yes
- [x] No

## Describe the changes

Disable the warning of stylelint about **max-empty-lines** rule when launching storybook

Github issue number or Jira issue URL: **Quick fix**

## Other informations
