### PR TITLE
fix(website/links): repair broken links in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can report any bug or request a feature or improvment [filling an issue here
 
 ## Installation
 
-Please follow the [installation guide](https://mozaic.adeo.cloud/Contributing/Prerequisite/InstallForDev/)
+Please follow the [installation guide](https://mozaic.adeo.cloud/Contributing/Developers/InstallForDev/)
 
 ## Design system core team
 

--- a/src/docs/Components/Buttons/code.mdx
+++ b/src/docs/Components/Buttons/code.mdx
@@ -189,7 +189,7 @@ This mean that you can override or create buttons themes and the associated clas
 
 <Highlight title="Read first">
 
-Read our [customization documentation first](GetStarted/Developers/CustomizeTokens/) first to see how to customize tokens.
+Read our [customization documentation first](/GetStarted/Developers/CustomizeTokens/) first to see how to customize tokens.
 
 </Highlight>
 

--- a/src/docs/Components/Flags/index.mdx
+++ b/src/docs/Components/Flags/index.mdx
@@ -10,7 +10,7 @@ searchKeywords: 'pills category label Badge'
 
 > A flag is used to display meta-informations about a product or a service. It must be displayed at the top of the content, and used as an indicator of a content main category.
 
-Please use a [tag](/Components/Tags/) if you need to display additional information.
+Please use a [tag](/Components/Tag/) if you need to display additional information.
 
 <Preview path="flag-all" nude />
 

--- a/src/docs/Contributing/Designers/AddNewIcons/index.mdx
+++ b/src/docs/Contributing/Designers/AddNewIcons/index.mdx
@@ -9,7 +9,7 @@ order: 4
 
 Before wanting to add a new icon you should ask yourself if that's a real need or just a desire. Our icons must be easy to understand and have a real meaning. That is why we encourage you to ask yourself this question: Does my user need this icon ? When this question is solved you should know a few things about our [process](/Contributing/SubmitChanges/AddNewPattern/). Every icon produced for Mozaic by yourself or our designers in charge will have to answer these [foundations](/Foundations/Icons/designers/) and will be reviewed by our team.
 
-Now that you know you need this new icon please [get in touch](Contributing/Designers/AddNewIcons/#1-get-in-touch-with-mozaics-team) with Mozaic's design team. As far as tools are concerned we work with Adobe Illustrator and Sketch to do the whole process.
+Now that you know you need this new icon please [get in touch](/Contributing/Designers/AddNewIcons/#1-get-in-touch-with-mozaics-team) with Mozaic's design team. As far as tools are concerned we work with Adobe Illustrator and Sketch to do the whole process.
 
 # I'm a designer working on Mozaic
 
@@ -19,7 +19,7 @@ We would like to advise you to read this [documentation](/Foundations/Icons/desi
 
 ## 1. Get in touch with Mozaic's team
 
-It's important to discuss your needs and what can be produced together before starting to create the preivously mentioned icon. Our icon designers are available on Slack (#mozaic-support). Get in touch with them to speak about format and sizes of your icon(s). You can also reach Mozaic's team on different [channels](https://mozaic.adeo.cloud/Help/).
+It's important to discuss your needs and what can be produced together before starting to create the preivously mentioned icon. Our icon designers are available on Slack (#mozaic-support). Get in touch with them to speak about format and sizes of your icon(s). You can also reach Mozaic's team on different [channels](/Help/).
 
 ## 2. Icon design phase
 

--- a/src/docs/Contributing/Designers/DesignToolsConventions/index.mdx
+++ b/src/docs/Contributing/Designers/DesignToolsConventions/index.mdx
@@ -15,7 +15,7 @@ This **Definition of Done** page has been divided in 10 steps.
 
 I checked that the pattern is not in another library or in a current issue :
 
-- I looked over Mozaic’s website ([Foundations](https://mozaic.adeo.cloud/Foundations/) / [Components](https://mozaic.adeo.cloud/Components/))
+- I looked over Mozaic’s website ([Foundations](/Foundations/) / [Components](/Components/))
 - I checked on GitHub ([Pull requests](https://github.com/adeo/mozaic-design-system/pulls))
 - I checked on [Jira](https://design-system-adeo.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=MZC&atlOrigin=eyJpIjoiYTI4ZDJhMmU2MTE1NGQyN2FmNWQxYTE3MjkzODAwMjUiLCJwIjoiaiJ9) (Issues in the kanban board)
 
@@ -27,7 +27,7 @@ I checked that my pattern is in the right Sketch library and it’s in somewhere
 
 A design system needs to respond to a certain number of criterias. Naming conventions is one of the most important. It helps file organization and generates a common language.
 
-> Please read the [naming convention documentation](https://mozaic.adeo.cloud/GetStarted/Designers/namingConvention/) to find out more informations about that.
+> Please read the [naming convention documentation](/GetStarted/Designers/namingConvention/) to find out more informations about that.
 
 ### 4. Every symbols are usable and responsive
 
@@ -43,7 +43,7 @@ We created layer and text styles to make the symbol creation process easier. Mak
 
 Every element must use our magic unit standard which is 1 magic unit for 16 pixels.
 
-> Please read the [Magic Unit documentation](https://mozaic.adeo.cloud/Foundations/MagicUnit/) to find out more informations about that.
+> Please read the [Magic Unit documentation](/Foundations/MagicUnit/) to find out more informations about that.
 
 ### 7. Every patterns coming from other libraries are up to date
 
@@ -77,7 +77,7 @@ This **Definition of Done** page has been divided in 9 steps.
 
 I checked that the pattern is not in another library or in a current issue :
 
-- I looked over Mozaic’s website ([Foundations](https://mozaic.adeo.cloud/Foundations/) / [Components](https://mozaic.adeo.cloud/Components/))
+- I looked over Mozaic’s website ([Foundations](/Foundations/) / [Components](/Components/))
 - I checked on GitHub ([Pull requests](https://github.com/adeo/mozaic-design-system/pulls))
 - I checked on [Jira](https://design-system-adeo.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=MZC&atlOrigin=eyJpIjoiYTI4ZDJhMmU2MTE1NGQyN2FmNWQxYTE3MjkzODAwMjUiLCJwIjoiaiJ9) (Issues in the kanban board)
 
@@ -89,7 +89,7 @@ I checked that my pattern is in the right Figma library and it’s in somewhere 
 
 A design system needs to respond to a certain number of criterias. Naming conventions is one of the most important. It helps file organization and generates a common language.
 
-> Please read the [naming convention documentation](https://mozaic.adeo.cloud/GetStarted/Designers/namingConvention/) to find out more informations about that.
+> Please read the [naming convention documentation](/GetStarted/Designers/namingConvention/) to find out more informations about that.
 
 ### 4. Every components are usable and responsive
 
@@ -105,7 +105,7 @@ We created layer and text styles to make the component creation process easier. 
 
 Every element must use our magic unit standard which is 1 magic unit for 16 pixels.
 
-> Please read the [Magic Unit documentation](https://mozaic.adeo.cloud/Foundations/MagicUnit/) to find out more informations about that.
+> Please read the [Magic Unit documentation](/Foundations/MagicUnit/) to find out more informations about that.
 
 ### 7. Every patterns coming from other libraries are up to date
 
@@ -127,7 +127,7 @@ You can download the [designer kit](https://github.com/adeo/design-system--style
 
 > From a designer point of view, Mozaic is based on Sketch and Abstract. Abstract is a versioning software for design files and allows teams to collaborate with a modern workflow. Like a developer does in GitHub, you need to ask for a review before merging your branches. We wrote some rules to follow before clicking **_Request Review_** on Abstract.
 
-## 1. The symbols have been created following the [definition of Done for symbols](/Contributing/SubmitChanges/DesignToolsConventions/#sketch) for designers.
+## 1. The symbols have been created following the Definition Of Done previously evoked.
 
 We wrote some definition of done rules when you create some symbols in Sketch. Please read these instructions before submitting a review on Abstract. It will make the process way easier for us and we thank you for that 🤘.
 

--- a/src/docs/Contributing/Developers/CSSConventions/index.mdx
+++ b/src/docs/Contributing/Developers/CSSConventions/index.mdx
@@ -436,7 +436,7 @@ Output :
 
 ## MQpacker / medias queries grouping
 
-All Mozaic blocks/components should be wrapped in `/* mqp:start */` and `/* mqp:end */` comments to enable [MQpacker](/Foundations/Layout/Responsive/code/) :
+All Mozaic blocks/components should be wrapped in `/* mqp:start */` and `/* mqp:end */` comments to enable [MQpacker](/Foundations/Layout/Responsive/code/#using-mqpacker-to-group-média-queries) :
 
 ```scss
 /* mqp:start */
@@ -536,7 +536,7 @@ Add also **the version in witch the support is supposed to be dropped**.
 ## Tokens comment
 
 Design tokens are theming/styling constants defined in a JSON file.
-For more information about tokens, please read the ["Design Tokens" chapter](http://mozaic.adeo.cloud/GetStarted/Developers/whatsincluded/#design-tokens) in the **Getting started** section.
+For more information about tokens, please read the ["Design Tokens" chapter](/GetStarted/Developers/whatsincluded/#design-tokens-) in the **Getting started** section.
 
 It is possible to add a comment to a token property, simply by adding a new `key/value` pair to the JSON file.
 The key must be named `comment` and the value contains the comment you want to write.

--- a/src/docs/Contributing/Developers/InstallForDev/index.mdx
+++ b/src/docs/Contributing/Developers/InstallForDev/index.mdx
@@ -24,7 +24,7 @@ The project use a monorepo architecture using [lerna](https://github.com/lerna/l
 Lerna help us to manage the distribution and the versioning of multiple packages into the same repository.
 It also create symlink between the individual packages nodes_modules so they can be used in one another as npm dependencies.
 
-When releasing the design system, lerna will automatically generate changelogs for the global/parent repo, as well as for the individual packages and select a version number based on the commit syntax. It's why it is very important that you follow the [contributing guidelines](/Contributing/Prerequisite/GitConventions/).
+When releasing the design system, lerna will automatically generate changelogs for the global/parent repo, as well as for the individual packages and select a version number based on the commit syntax. It's why it is very important that you follow the [contributing guidelines](/Contributing/Developers/GitConventions/).
 
 Please [read the docs](https://github.com/lerna/lerna/) to learn more about it.
 

--- a/src/docs/Contributing/SubmitChanges/AddNewPattern/index.mdx
+++ b/src/docs/Contributing/SubmitChanges/AddNewPattern/index.mdx
@@ -3,7 +3,7 @@ title: 'Add a new pattern'
 order: 6
 ---
 
-> If you are a designer you also need to read the [Definition of Done for Sketch symbols contribution](/Contributing/SubmitChanges/DesignToolsConventions/#sketch) page
+> If you are a designer you also need to read the [Definition of Done for Sketch symbols contribution](/Contributing/Designers/DesignToolsConventions/#sketch) page
 
 MOZAIC being an evolving and collaborative tool, you are free to propose new patterns.
 
@@ -14,7 +14,7 @@ However, here are some recommendations to take into account before you start:
 First of all, please check that the pattern you want to create doesn't already exist or isn't being created.  
 For that, all you need to do is to:
 
-- Check on the MOZAIC website ([Foundations](http://mozaic.adeo.cloud/Foundations/) / [Components](http://mozaic.adeo.cloud/Components/))
+- Check on the MOZAIC website ([Foundations](/Foundations/) / [Components](/Components/))
 - Check on Github ([Pull requests](https://github.com/adeo/mozaic-design-system/pulls))
 - Check on Jira ([Issues in the kanban board](https://design-system-adeo.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=MZC&atlOrigin=eyJpIjoiYTI4ZDJhMmU2MTE1NGQyN2FmNWQxYTE3MjkzODAwMjUiLCJwIjoiaiJ9))
 - Ask the question to the core team MOZAIC via the channel **#mozaic-support** on [Slack](https://adeo-tech-community.slack.com/)

--- a/src/docs/Contributing/SubmitChanges/PatternEnhancement/index.mdx
+++ b/src/docs/Contributing/SubmitChanges/PatternEnhancement/index.mdx
@@ -37,6 +37,6 @@ Another method _(recommended)_ is to create an **Issue** in the [MOZAIC project 
 
 If you have the opportunity, you can directly submit the improvement you want to implement by creating a Pull Request.
 
-For more details, please read our [documentation about Pull Request](/Contributing/Prerequisite/GitConventions/#pull-requests).
+For more details, please read our [documentation about Pull Request](/Contributing/Developers/GitConventions/#pull-requests).
 
 Note that a pattern enhancement require only the core team validation to be merged.

--- a/src/docs/Contributing/SubmitChanges/SubmitBugFix/index.mdx
+++ b/src/docs/Contributing/SubmitChanges/SubmitBugFix/index.mdx
@@ -5,7 +5,7 @@ order: 7
 
 If you want to fix a bug, prior to that it is better to have a related issue or jira ticket describing the bug, and a quick talk with the core team.
 The core team can provide time saving informations and guidance.
-First read the [report a bug section](/Contributing/ReportBug)
+First read the [report a bug section](/ReportBug/)
 
 If you are quite sure about the bug you want to adress, and that nobody already working on it, we encourage you to create a pull request.
 
@@ -15,8 +15,8 @@ If you have the opportunity, we recommend you to submit a **Pull Request** conta
 
 ### We will check that the PR…
 
-- The PR title and commits messages follows [our conventions](/Contributing/Prerequisite/GitConventions/)
-- If it is related to CSS, that the PR follow [our css conventions](/Contributing/Prerequisite/CSSConventions/)
+- The PR title and commits messages follows [our conventions](/Contributing/Developers/GitConventions/)
+- If it is related to CSS, that the PR follow [our css conventions](/Contributing/Developers/CSSConventions/)
 - The docs are updated if necessary
 - That there is no breaking changes
 - That the fix do not have undesired sides effects
@@ -24,7 +24,7 @@ If you have the opportunity, we recommend you to submit a **Pull Request** conta
 ## Submit a fix on a sketch library
 
 If the bug fix is related to a sketch library :
-Please follow the [designer contribution guidelines](/Contributing/SubmitChanges/DesignToolsConventions/)
+Please follow the [designer contribution guidelines](/Contributing/Designers/DesignToolsConventions/)
 
 ## Merge criterias
 

--- a/src/docs/Contributing/SubmitChanges/SubmitNewPattern/index.mdx
+++ b/src/docs/Contributing/SubmitChanges/SubmitNewPattern/index.mdx
@@ -65,6 +65,6 @@ Your folder may also contain an implementation of the pattern's scss/js code wit
 
 Once you have finished working on your pattern, it is time to push your branch and create a Pull Request associated with your work.
 
-Please respect the [Git conventions](/Contributing/Prerequisite/GitConventions/) that we defined before pushing your work.
+Please respect the [Git conventions](/Contributing/Developers/GitConventions/) that we defined before pushing your work.
 
-You will also find in the [Git conventions](/Contributing/Prerequisite/GitConventions/#pull-requests) page, the recommended method to make your Pull Request.
+You will also find in the [Git conventions](/Contributing/Developers/GitConventions/#pull-requests) page, the recommended method to make your Pull Request.

--- a/src/docs/Foundations/Colors/index.mdx
+++ b/src/docs/Foundations/Colors/index.mdx
@@ -7,7 +7,7 @@ status:
   scss: 'stable'
 ---
 
-> Mozaic offers an adaptive and a scalable color system. These colors have been defined using [HSLA](#hsla) color swatches. The color palette has been divided in four categories : **Primary colors**, **Secondary colors** ,**Greys** and **Status colors**.
+> Mozaic offers an adaptive and a scalable color system. These colors have been defined using [HSLA](/Foundations/Colors/#anatomy) color swatches. The color palette has been divided in four categories : **Primary colors**, **Secondary colors** ,**Greys** and **Status colors**.
 
 
 <Highlight theme="warning" title="Be aware">

--- a/src/docs/Foundations/Typography/ScaleAndSizes/index.mdx
+++ b/src/docs/Foundations/Typography/ScaleAndSizes/index.mdx
@@ -82,4 +82,4 @@ You can use any of the previous line-height depending on your needs, but conside
 
 <br />
 
-\*mu : [magic unit](/Foundations/magicUnit/)
+\*mu : [magic unit](/Foundations/MagicUnit/)

--- a/src/docs/GetStarted/Developers/CustomizeTokens/index.mdx
+++ b/src/docs/GetStarted/Developers/CustomizeTokens/index.mdx
@@ -20,7 +20,7 @@ As a reminder, we call tokens a series of Json files containing mostly color val
 Read the following documentations :
 
 [Getting started : Variables and design tokens](/GetStarted/Developers/CssNamingConventions/#variables-and-design-tokens)  
-[Contributting : design tokens](/Contributing/Prerequisite/DesignTokens/)
+[Contributting : design tokens](/Contributing/Developers/DesignTokens/)
 
 </Highlight>
 

--- a/src/docs/GetStarted/Developers/configureStylelint/index.mdx
+++ b/src/docs/GetStarted/Developers/configureStylelint/index.mdx
@@ -25,7 +25,7 @@ In some cases you may want to configure it, for example **to configure prettier-
 </Highlight>
 
 
- For example, you may want to create a npm script to automatically fix linting issues.
+For example, you may want to create a npm script to automatically fix linting issues.
 
 In that case you can create a `stylelint.config.js` file in the root dir of your project.
 
@@ -57,7 +57,7 @@ defaultConfig: {
 
 <Highlight title="More informations here">
 
-Please checkout [Mozaic configuration](GetStarted/Developers/Configuration/#stylelint-options-) for more information. 
+Please checkout [Mozaic configuration](/GetStarted/Developers/Configuration/#stylelint-options-) for more information. 
 
 </Highlight>
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -187,11 +187,11 @@ const Navigation = () => (
   <NavWrapper>
     <Container>
       <Nav>
-        <NavLink to="/GetStarted">Get Started</NavLink>
-        <NavLink to="/Foundations">Documentation</NavLink>
-        <NavLink to="/Contributing">Contribute</NavLink>
-        <NavLink to="/Updates">What's new</NavLink>
-        <NavLink to="/Help">Contact us</NavLink>
+        <NavLink to="/GetStarted/">Get Started</NavLink>
+        <NavLink to="/Foundations/">Documentation</NavLink>
+        <NavLink to="/Contributing/">Contribute</NavLink>
+        <NavLink to="/Updates/">What's new</NavLink>
+        <NavLink to="/Help/">Contact us</NavLink>
       </Nav>
     </Container>
   </NavWrapper>


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a breaking change?

read [What is a breaking change ?](https://mozaic.adeo.cloud/Contributing/Prerequisite/GitConventions/#breaking-changes-)

- [ ] Yes
- [x] No

## Describe the changes

Some links are broken in the documentation, we need to fix them.

Github issue number or Jira issue URL: https://design-system-adeo.atlassian.net/browse/MZC-347

## Other informations
