### PR TITLE
fix(pattern/magic-unit): add $mu175 variable and spell-check

### DIFF
--- a/packages/styles/settings-tools/_s.magic-unit.scss
+++ b/packages/styles/settings-tools/_s.magic-unit.scss
@@ -65,6 +65,7 @@ $mu075: magic-unit-rem(0.75);
 $mu100: magic-unit-rem(1);
 $mu125: magic-unit-rem(1.25);
 $mu150: magic-unit-rem(1.5);
+$mu175: magic-unit-rem(1.75);
 $mu200: magic-unit-rem(2);
 $mu250: magic-unit-rem(2.5);
 $mu300: magic-unit-rem(3);

--- a/src/docs/Foundations/MagicUnit/code.mdx
+++ b/src/docs/Foundations/MagicUnit/code.mdx
@@ -7,16 +7,16 @@ order: 1
 
 The magic unit is a `scss` variable generated from tokens: `$magic-unit`.
 
-This variable is an unitless value equal to `16`.
+This variable is a unitless value equal to `16`.
 
-## Why an unitless value?
+## Why a unitless value?
 
-First, we whant to express sizes in `rem` units.
+First, we want to express sizes in `rem` units.
 If you don't know why, [read this first](https://www.sitepoint.com/understanding-and-using-rem-units-in-css/).
 
 ### So, what's the problem?
 
-Well, depending on the team code base that use it, the value of `1rem` may be different... The value of `1rem` is defined by the `font-size` property attached to the root element (html on the web).
+Well, depending on the team code base that uses it, the value of `1rem` may be different... The value of `1rem` is defined by the `font-size` property attached to the root element (html on the web).
 
 ```scss
 /* it's not uncommon to see this */
@@ -29,7 +29,7 @@ html {
 }
 ```
 
-By default, the `rem` is equal to `16px` :
+By default, the `rem` is equal to `16px`:
 
 ```scss
 html {
@@ -43,7 +43,7 @@ html {
 
 ### Ok, so how do we make this work?
 
-We added a token where you can define your local pixel value of `1rem`. It's exposed in scss as `$local-rem-value`. This value is set to `16` by default. Then, to get a rem value of `$magic-unit`, we divide it by `$local-rem-value` :
+We added a token where you can define your local pixel value of `1rem`. It's exposed in scss as `$local-rem-value`. This value is set to `16` by default. Then, to get a rem value of `$magic-unit`, we divide it by `$local-rem-value`:
 
 ```scss
 @import 'settings-tools/all-settings';
@@ -57,9 +57,9 @@ We added a token where you can define your local pixel value of `1rem`. It's exp
 }
 ```
 
-To make things easier, we created a sass function that do that for you :
+To make things easier, we created a sass function that do that for you:
 
-**the `to-rem()` sass function :**
+**the `to-rem()` sass function:**
 
 ```scss
 @import 'settings-tools/all-settings';
@@ -69,19 +69,19 @@ To make things easier, we created a sass function that do that for you :
 }
 ```
 
-## You got it ! But there is more:
+## You got it! But there is more:
 
-We created multiple things to help you work better with the magic unit :
+We created multiple things to help you work better with the magic unit:
 
 - the function `magic-unit()`
 - the function `magic-unit-rem()`
 - the variables `$mu025` to `$mu1000`
 
-here their respectives API :
+here their respectives API:
 
 ### The magic-unit function
 
-> The **magic-unit function** return an **unitless** multiplictaion of the magic unit **expressed in px**, and expect a **multiplier** parameter.
+> The **magic-unit function** returns a **unitless** multiplication of the magic unit **expressed in px**, and expects a **multiplier** parameter.
 
 Following the rules of granularity, it will accept a multiplier parameter:
 
@@ -89,11 +89,11 @@ Following the rules of granularity, it will accept a multiplier parameter:
 - of `0.5` increments for multipliers greater than 2 and less than 4
 - integers for multipliers greater than 4
 
-**it is particularily usefull when you need to make calculations.**
+**It is particularly useful when you need to make calculations.**
 
-Imagine you create a button. You whant it to have exactly 2.5 x magic-unit height when on one line, but still be able to grow in unexpected uses-cases, if the text is forced on two lines.
+Imagine you create a button. You want it to have exactly 2.5 x magic-unit height when on one line, but still be able to grow in unexpected uses cases, if the text is forced on two lines.
 
-One valid approach could be the following :
+One valid approach could be the following:
 
 ```scss
 @import 'settings-tools/all-settings';
@@ -111,16 +111,16 @@ One valid approach could be the following :
 
 <Hint type="dont">
     <HintItem dont>
-        Dont use an invalid multiplier parameter : <code>magic-unit(0.6792)</code>. <br />The magic-unit function will throw an error and prevent the css compilation
+        Don't use an invalid multiplier parameter: <code>magic-unit(0.6792)</code>. <br />The magic-unit function will throw an error and prevent the css compilation.
     </HintItem>
     <HintItem dont>
-        Avoid using custom multiplications : <code>magic-unit*12</code>. <br /> That way you can be sure to use an authorized value.
+        Avoid using custom multiplications: <code>magic-unit*12</code>. <br /> That way you can be sure to use an authorized value.
     </HintItem>
 </Hint>
 
 ### The magic-unit-rem function
 
-> The **magic-unit-rem function** behave exactly as the magic-unit function does, exept **it return a rem value**.
+> The **magic-unit-rem function** behaves exactly as the magic-unit function does, exept **it returns a rem value**.
 
 It basically just do the `to-rem()` part for you
 
@@ -136,11 +136,11 @@ It basically just do the `to-rem()` part for you
 
 ### The shorthands variables
 
-> The **shorthands variables** behave exactly as the magic-unit-rem, but in a variable form factor.
+> The **shorthands variables** behaves exactly as the magic-unit-rem, but in a variable form factor.
 
 ### The magic unit grid development utility
 
-In order to help you to position your elements as well as possible according to the magic-unit, Mozaic provides the css class `mdu-magic-unit-grid` to add on your container and which allows the display of a positioning grid.
+In order to help you to position your elements according to the magic-unit, Mozaic provides the css class `mdu-magic-unit-grid` to apply on your container and shows a positioning grid.
 
 The `mdu-magic-unit-grid` class is only usable in a development mode, indeed the code of this class will not be compiled into the production build when the **MOZAIC_ENV=production** environment variable is provided.
 

--- a/src/docs/Foundations/MagicUnit/code.mdx
+++ b/src/docs/Foundations/MagicUnit/code.mdx
@@ -3,18 +3,18 @@ title: 'Code'
 order: 1
 ---
 
-# Using magic unit in SCSS :
+# Using magic unit in SCSS
 
-The magic unit is a `scss` variable generated from tokens: `$magic-unit` .
+The magic unit is a `scss` variable generated from tokens: `$magic-unit`.
 
-this variable is an unitless value equal to `16` .
+This variable is an unitless value equal to `16`.
 
-## Why an unitless value ?
+## Why an unitless value?
 
 First, we whant to express sizes in `rem` units.
-If you don't know why, [read this first](https://www.sitepoint.com/understanding-and-using-rem-units-in-css/)
+If you don't know why, [read this first](https://www.sitepoint.com/understanding-and-using-rem-units-in-css/).
 
-### So, what's the problem ?
+### So, what's the problem?
 
 Well, depending on the team code base that use it, the value of `1rem` may be different... The value of `1rem` is defined by the `font-size` property attached to the root element (html on the web).
 
@@ -29,7 +29,7 @@ html {
 }
 ```
 
-by default, the `rem` is equal to `16px` :
+By default, the `rem` is equal to `16px` :
 
 ```scss
 html {
@@ -41,7 +41,7 @@ html {
 }
 ```
 
-### Ok, so how do we make this work ?
+### Ok, so how do we make this work?
 
 We added a token where you can define your local pixel value of `1rem`. It's exposed in scss as `$local-rem-value`. This value is set to `16` by default. Then, to get a rem value of `$magic-unit`, we divide it by `$local-rem-value` :
 
@@ -69,7 +69,7 @@ To make things easier, we created a sass function that do that for you :
 }
 ```
 
-## You got it ! But there is more :
+## You got it ! But there is more:
 
 We created multiple things to help you work better with the magic unit :
 
@@ -79,21 +79,21 @@ We created multiple things to help you work better with the magic unit :
 
 here their respectives API :
 
-### The magic-unit function :
+### The magic-unit function
 
-> the **magic-unit function** return an **unitless** multiplictaion of the magic unit **expressed in px**, and expect a **multiplier** parameter.
+> The **magic-unit function** return an **unitless** multiplictaion of the magic unit **expressed in px**, and expect a **multiplier** parameter.
 
-folowing the rules of granularity, it will accept a multiplier parameter:
+Following the rules of granularity, it will accept a multiplier parameter:
 
-- of 0.25 increments for multiplier less than 2
-- of 0.5 increments for multipliers greater than 2 and less than 4
+- of `0.25` increments for multiplier less than 2
+- of `0.5` increments for multipliers greater than 2 and less than 4
 - integers for multipliers greater than 4
 
 **it is particularily usefull when you need to make calculations.**
 
 Imagine you create a button. You whant it to have exactly 2.5 x magic-unit height when on one line, but still be able to grow in unexpected uses-cases, if the text is forced on two lines.
 
-One valid approach could be the folowing :
+One valid approach could be the following :
 
 ```scss
 @import 'settings-tools/all-settings';
@@ -114,13 +114,13 @@ One valid approach could be the folowing :
         Dont use an invalid multiplier parameter : <code>magic-unit(0.6792)</code>. <br />The magic-unit function will throw an error and prevent the css compilation
     </HintItem>
     <HintItem dont>
-        Avoid using custom multiplications : <code>magic-unit*12</code>. <br /> that way you can be sure to use an authorized value.
+        Avoid using custom multiplications : <code>magic-unit*12</code>. <br /> That way you can be sure to use an authorized value.
     </HintItem>
 </Hint>
 
-### The magic-unit-rem function :
+### The magic-unit-rem function
 
-> the **magic-unit-rem function** behave exactly as the magic-unit function does, exept **it return a rem value**.
+> The **magic-unit-rem function** behave exactly as the magic-unit function does, exept **it return a rem value**.
 
 It basically just do the `to-rem()` part for you
 
@@ -134,11 +134,11 @@ It basically just do the `to-rem()` part for you
 }
 ```
 
-### The shorthands variables :
+### The shorthands variables
 
-> the **shorthands variables** behave exactly as the magic-unit-rem, but in a variable form factor.
+> The **shorthands variables** behave exactly as the magic-unit-rem, but in a variable form factor.
 
-### The magic unit grid development utility :
+### The magic unit grid development utility
 
 In order to help you to position your elements as well as possible according to the magic-unit, Mozaic provides the css class `mdu-magic-unit-grid` to add on your container and which allows the display of a positioning grid.
 

--- a/src/docs/Foundations/MagicUnit/index.mdx
+++ b/src/docs/Foundations/MagicUnit/index.mdx
@@ -6,22 +6,22 @@ status:
   scss: 'stable'
 ---
 
-> **The magic unit is a base unit for any element or property that require a defined dimension**. It is equal to **16px** but is expressed in **rem**.<br /> We multiply or divide it to define white spaces, icons sizes, lines heights etc...
+> **The magic unit is a base unit for any element or property that require a defined dimension**. It is equal to **16px** but is expressed in **rem**.<br /> We multiply or divide it to define white spaces, icons sizes, line-heights etc...
 
-## Why do we use the magic unit ?
+## Why do we use the magic unit?
 
-Using a magic unit have multiples benefits.
+Using a magic unit have multiple benefits.
 
 - It make the overall compositions feels more **harmonious and organised**.
 - It help create a sense of vertical rythm (or baseline)
 - It help create **consistantly sized and spaced elements**
-- Therefore it improve **modularity and reusability**. _Just drop common elements next to each others, there is a good chance that they will fit the same vertical space and be perfectly aligned_.
+- Therefore it improves **modularity and reusability**. _Just drop common elements next to each others, there is a good chance that they will fit the same vertical space and be perfectly aligned_.
 
 <br />
 
-In the following exemple, we see a **grid in the background based on the magic unit**. It is subdivised in halfs and quarters to give us more fine control for small elements that require it.
+In the following example, we see a **grid in the background based on the magic unit**. It is subdivised in halfs and quarters to give us better control for small elements that require it.
 We can see the red squares snaping to the magic unit grid.
-By **hovering the squares**, you can see how we used the magic unit and the conrresponding values in Px :
+By **hovering the squares**, you can see how we used the magic unit and the corresponding values in Px:
 
 <Preview path="magic-unit" />
 <br />
@@ -46,7 +46,7 @@ The level of granularity that can be used depend of the size of what you are try
 </HintItem>
 <br />
 
-### Exemples of good values:
+### Examples of good values:
 
 <Hint title="A good usage of the magic unit">
   <table>
@@ -160,7 +160,7 @@ The level of granularity that can be used depend of the size of what you are try
   </table>
 </Hint>
 
-### Magic unit usage by properties :
+### Magic unit usage by properties:
 
 <br />
 <HintItem>Use for lines heights</HintItem>
@@ -178,7 +178,7 @@ The level of granularity that can be used depend of the size of what you are try
 </HintItem>
 <br />
 
-#### Keep in mind that most elements should be designed to be able to grow and and strech with responsiveness and accessibility in mind :
+#### Keep in mind that most elements should be designed to be able to grow and and strech with responsiveness and accessibility in mind:
 
 - Elements may be used by other teams in various layout configurations.
 - Browsers, devices, or even plugins dedicated to disabled users may change the way things are displayed.

--- a/src/docs/Foundations/MagicUnit/index.mdx
+++ b/src/docs/Foundations/MagicUnit/index.mdx
@@ -15,11 +15,11 @@ Using a magic unit have multiples benefits.
 - It make the overall compositions feels more **harmonious and organised**.
 - It help create a sense of vertical rythm (or baseline)
 - It help create **consistantly sized and spaced elements**
-- Therefore it improve **modularity, and reusability**. _Just drop common elements next to each others, there is a good chance that they will fit the same vertical space and be perfectly aligned_.
+- Therefore it improve **modularity and reusability**. _Just drop common elements next to each others, there is a good chance that they will fit the same vertical space and be perfectly aligned_.
 
 <br />
 
-In the folowing exemple, we see a **grid in the background based on the magic unit**. It is subdivised in halfs and quarters to give us more fine control for small elements that require it.
+In the following exemple, we see a **grid in the background based on the magic unit**. It is subdivised in halfs and quarters to give us more fine control for small elements that require it.
 We can see the red squares snaping to the magic unit grid.
 By **hovering the squares**, you can see how we used the magic unit and the conrresponding values in Px :
 
@@ -37,7 +37,7 @@ The level of granularity that can be used depend of the size of what you are try
   <b>less than two times the magic unit</b>
 </HintItem>
 <HintItem>
-  Use <b>alfs</b> of magic unit for sizes{' '}
+  Use <b>half</b> of magic unit for sizes{' '}
   <b>between two and four times the magic unit</b>
 </HintItem>
 <HintItem>

--- a/src/docs/Foundations/MagicUnit/sheatsheat.mdx
+++ b/src/docs/Foundations/MagicUnit/sheatsheat.mdx
@@ -5,131 +5,24 @@ order: 2
 
 <Preview path="magic-unit" />
 
-<br /><br />
-
-<table>
-  <thead>
-    <tr>
-      <th>Pixel value</th>
-      <th>Variable name</th>
-      <th>magic-unit-rem function</th>
-      <th>magic-unit function</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><b>4px</b></td>
-      <td>$mu025</td>
-      <td>magic-unit-rem(0.25)</td>
-      <td>magic-unit(0.25)</td>
-    </tr>
-    <tr>
-      <td><b>8px</b></td>
-      <td>$mu050</td>
-      <td>magic-unit-rem(0.5)</td>
-      <td>magic-unit(0.5)</td>
-    </tr>
-    <tr>
-      <td><b>12px</b></td>
-      <td>$mu075</td>
-      <td>magic-unit-rem(0.75)</td>
-      <td>magic-unit(0.75)</td>
-    </tr>
-    <tr>
-      <td><b>16px</b></td>
-      <td>$mu100</td>
-      <td>magic-unit-rem(1)</td>
-      <td>magic-unit(1)</td>
-    </tr>
-    <tr>
-      <td><b>20px</b></td>
-      <td>$mu125</td>
-      <td>magic-unit-rem(1.25)</td>
-      <td>magic-unit(1.25)</td>
-    </tr>
-    <tr>
-      <td><b>24px</b></td>
-      <td>$mu150</td>
-      <td>magic-unit-rem(1.5)</td>
-      <td>magic-unit(1.5)</td>
-    </tr>
-    <tr>
-      <td><b>28px</b></td>
-      <td>$mu175</td>
-      <td>magic-unit-rem(1.75)</td>
-      <td>magic-unit(1.75)</td>
-    </tr>
-    <tr>
-      <td><b>32px</b></td>
-      <td>$mu200</td>
-      <td>magic-unit-rem(2)</td>
-      <td>magic-unit(2)</td>
-    </tr>
-    <tr>
-      <td><b>40px</b></td>
-      <td>$mu250</td>
-      <td>magic-unit-rem(2.5)</td>
-      <td>magic-unit(2.5)</td>
-    </tr>
-    <tr>
-      <td><b>48px</b></td>
-      <td>$mu300</td>
-      <td>magic-unit-rem(3)</td>
-      <td>magic-unit(3)</td>
-    </tr>
-    <tr>
-      <td><b>56px</b></td>
-      <td>$mu350</td>
-      <td>magic-unit-rem(3.5)</td>
-      <td>magic-unit(3.5)</td>
-    </tr>
-    <tr>
-      <td><b>64px</b></td>
-      <td>$mu400</td>
-      <td>magic-unit-rem(4)</td>
-      <td>magic-unit(4)</td>
-    </tr>
-    <tr>
-      <td><b>80px</b></td>
-      <td>$mu500</td>
-      <td>magic-unit-rem(5)</td>
-      <td>magic-unit(5)</td>
-    </tr>
-    <tr>
-      <td><b>96px</b></td>
-      <td>$mu600</td>
-      <td>magic-unit-rem(6)</td>
-      <td>magic-unit(6)</td>
-    </tr>
-    <tr>
-      <td><b>112px</b></td>
-      <td>$mu700</td>
-      <td>magic-unit-rem(7)</td>
-      <td>magic-unit(7)</td>
-    </tr>
-    <tr>
-      <td><b>112px</b></td>
-      <td>$mu800</td>
-      <td>magic-unit-rem(8)</td>
-      <td>magic-unit(8)</td>
-    </tr>
-    <tr>
-      <td><b>112px</b></td>
-      <td>$mu900</td>
-      <td>magic-unit-rem(9)</td>
-      <td>magic-unit(9)</td>
-    </tr>
-    <tr>
-      <td><b>112px</b></td>
-      <td>$mu1000</td>
-      <td>magic-unit-rem(1.0)</td>
-      <td>magic-unit(1.0)</td>
-    </tr>
-    <tr>
-      <td><b>etc...</b></td>
-      <td>no more variables</td>
-      <td>magic-unit-rem(...)</td>
-      <td>magic-unit(...)</td>
-    </tr>
-  </tbody>
-</table>
+| Pixel value     | Variable name     | magic-unit-rem function | magic-unit function |
+| --------------- | ----------------- | ----------------------- | ------------------- |
+| **4px**         | `$mu025`          | magic-unit-rem(0.25)    | magic-unit(0.25)    |
+| **8px**         | `$mu050`          | magic-unit-rem(0.5)     | magic-unit(0.5)     |
+| **12px**        | `$mu075`          | magic-unit-rem(0.75)    | magic-unit(0.75)    |
+| **16px**        | `$mu100`          | magic-unit-rem(1)       | magic-unit(1)       |
+| **20px**        | `$mu125`          | magic-unit-rem(1.25)    | magic-unit(1.25)    |
+| **24px**        | `$mu150`          | magic-unit-rem(1.5)     | magic-unit(1.5)     |
+| **28px**        | `$mu175`          | magic-unit-rem(1.75)    | magic-unit(1.75)    |
+| **32px**        | `$mu200`          | magic-unit-rem(2)       | magic-unit(2)       |
+| **40px**        | `$mu250`          | magic-unit-rem(2.5)     | magic-unit(2.5)     |
+| **48px**        | `$mu300`          | magic-unit-rem(3)       | magic-unit(3)       |
+| **56px**        | `$mu350`          | magic-unit-rem(3.5)     | magic-unit(3.5)     |
+| **64px**        | `$mu400`          | magic-unit-rem(4)       | magic-unit(4)       |
+| **80px**        | `$mu500`          | magic-unit-rem(5)       | magic-unit(5)       |
+| **96px**        | `$mu600`          | magic-unit-rem(6)       | magic-unit(6)       |
+| **112px**       | `$mu700`          | magic-unit-rem(7)       | magic-unit(7)       |
+| **128px**       | `$mu800`          | magic-unit-rem(8)       | magic-unit(8)       |
+| **144px**       | `$mu900`          | magic-unit-rem(9)       | magic-unit(9)       |
+| **160px**       | `$mu1000`         | magic-unit-rem(1.0)     | magic-unit(1.0)     |
+| **etc...**      | no more variables | magic-unit-rem(...)     | magic-unit(...)     |


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a breaking change?

read [What is a breaking change ?](https://mozaic.adeo.cloud/Contributing/Prerequisite/GitConventions/#breaking-changes-)

- [ ] Yes
- [x] No

The variable $mu175 (28px) is missing and at the same time correct some errors in the documentation.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Github issue number or Jira issue URL: [MZC-356](https://design-system-adeo.atlassian.net/browse/MZC-356)

## Other informations
