### PR TITLE
fix(patterns/notification): remove unnecessary css rules

### DIFF
--- a/packages/styles/components/_c.notification.scss
+++ b/packages/styles/components/_c.notification.scss
@@ -42,14 +42,8 @@ $notification-close-icon-color: get-token(color, notification, font);
   }
 
   &__title,
-  &__message,
-  &__link {
+  &__message {
     margin: 0;
-  }
-
-  &__link {
-    display: block;
-    text-decoration: underline;
   }
 
   &__title {
@@ -57,11 +51,8 @@ $notification-close-icon-color: get-token(color, notification, font);
     @include set-font-scale('05');
   }
 
-  &__title + &__message {
-    margin-top: $mu050;
-  }
-
-  &__message + &__link {
+  &__message,
+  &__link {
     margin-top: $mu050;
   }
 }


### PR DESCRIPTION
Fix #512

## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a breaking change?

read [What is a breaking change ?](https://mozaic.adeo.cloud/Contributing/Prerequisite/GitConventions/#breaking-changes-)

- [ ] Yes
- [x] No

## Describe the changes

Remove unnecessary css rules on the notification pattern

Github issue number or Jira issue URL: [ISSUE-512](https://github.com/adeo/mozaic-design-system/issues/512)

## Other informations
