### PR TITLE
fix(patterns/rating-stars): add background-size on rating stars input

### DIFF
--- a/packages/styles/components/_c.stars-input.scss
+++ b/packages/styles/components/_c.stars-input.scss
@@ -23,6 +23,7 @@
       url(inline-icons('star-full-32', $color-star-full)) repeat-x
       center center;
     border-radius: $stars-focus-radius;
+    background-size: $stars-default-bg-size $stars-default-bg-size;
     cursor: pointer;
 
     &::before {
@@ -83,6 +84,8 @@
 
           /* fix for ie11 */
           $bg-variation-size: map-deep-get($stars-sizes, $size, 'width');
+
+          background-size: $bg-variation-size $bg-variation-size;
 
           &::before {
             background-size: $bg-variation-size $bg-variation-size;


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Fix background-image size on rating-stars input

GitHub issue number or Jira issue URL: N/A

## Other information
