### PR TITLE
fix(patterns/buttons): fix regression on the color of icons

### DIFF
--- a/packages/styles/components/_c.button.scss
+++ b/packages/styles/components/_c.button.scss
@@ -7,6 +7,7 @@
   @include set-button-layout();
 
   box-sizing: border-box;
+  fill: currentColor;
 
   &:focus {
     @include add-demo-state-class {


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

There has been a regression on the color of the icons in the buttons.

GitHub issue number or Jira issue URL: QuickFix

## Other information
