### PR TITLE
fix(patterns/fileuploader): remove href attribute on fileuploader del…

### DIFF
--- a/src/docs/Components/FileUploader/code.mdx
+++ b/src/docs/Components/FileUploader/code.mdx
@@ -50,7 +50,11 @@ You can also restrict the type or the path of the file to be uploaded.
 
 ## Accessibility and semantic
 
-Don't forget to add the `aria-label` attribute on the `mc-fileuploader__input`
+<Highlight theme="tips">
+
+  Don't forget to add the `aria-label` attribute on the `mc-fileuploader__input`
+
+</Highlight>
 
 ## Display uploaded files and errors
 
@@ -65,12 +69,12 @@ Inside the file uploader, right after the `label`, add a list of files :
         <li class="mc-fileuploader__file mc-fileuploader__file--is-valid">
             <span class="mc-fileuploader__file-name">filename-valid.jpg</span>
             <span class="mc-fileuploader__file-icon"></span>
-            <button href="#" class="mc-fileuploader__delete"></button>
+            <button type="button" class="mc-fileuploader__delete"></button>
         </li>
         <li class="mc-fileuploader__file mc-fileuploader__file--is-invalid">
             <span class="mc-fileuploader__file-name">filename-invalid.jpg</span>
             <span class="mc-fileuploader__file-icon"></span>
-            <button href="#" class="mc-fileuploader__delete"></button>
+            <button type="button" class="mc-fileuploader__delete"></button>
             <div class="mc-fileuploader__file-message">
                 Oops, the file "filename-invalid.jpg" was not uploaded. please try again
             </div>

--- a/src/docs/Components/FileUploader/previews/file-uploader-with-file-delete.preview.html
+++ b/src/docs/Components/FileUploader/previews/file-uploader-with-file-delete.preview.html
@@ -15,12 +15,12 @@
       <li class="mc-fileuploader__file mc-fileuploader__file--is-valid">
         <span class="mc-fileuploader__file-name">filename-valid.jpg</span>
         <span class="mc-fileuploader__file-icon"></span>
-        <button href="#" class="mc-fileuploader__delete"></button>
+        <button type="button" class="mc-fileuploader__delete"></button>
       </li>
       <li class="mc-fileuploader__file mc-fileuploader__file--is-invalid">
         <span class="mc-fileuploader__file-name">filename-invalid.jpg</span>
         <span class="mc-fileuploader__file-icon"></span>
-        <button href="#" class="mc-fileuploader__delete"></button>
+        <button type="button" class="mc-fileuploader__delete"></button>
         <div class="mc-fileuploader__file-message">
           Oops, the file is not uploaded
         </div>


### PR DESCRIPTION
…ete button

Resolves #578

## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [s] No

## Describe the changes

Remove href attribute on fileuploader delete button

GitHub issue number or Jira issue URL: [ISSUE-578](https://github.com/adeo/mozaic-design-system/issues/578)

## Other information
