### PR TITLE
refactor(patterns/tooltip): add inline-flex on .mc-tooltip

### DIFF
--- a/packages/styles/components/_c.tooltip.scss
+++ b/packages/styles/components/_c.tooltip.scss
@@ -4,6 +4,7 @@
 
   @include set-font-face();
 
+  display: inline-flex;
   position: relative;
 
   &:focus,


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Added `inline-flex` rule to the `.mc-tooltip` component so that it doesn't take up all the available space.

GitHub issue number or Jira issue URL: N/A

## Other information
