### PR TITLE
fix(patterns/toggle): remove white-space property on .mc-toggle__label

### DIFF
--- a/packages/styles/components/_c.checkbox.scss
+++ b/packages/styles/components/_c.checkbox.scss
@@ -7,6 +7,7 @@
   &__label {
     @include set-font-scale('05', 'xs');
 
+    cursor: pointer;
     margin-left: magic-unit-rem(0.5, true);
   }
 

--- a/packages/styles/components/_c.radio.scss
+++ b/packages/styles/components/_c.radio.scss
@@ -7,6 +7,7 @@
   &__label {
     @include set-font-scale('05', 'xs');
 
+    cursor: pointer;
     margin-left: magic-unit-rem(0.5, true);
   }
 

--- a/packages/styles/components/_c.toggle.scss
+++ b/packages/styles/components/_c.toggle.scss
@@ -12,9 +12,8 @@
     @include set-toggle-size('m');
 
     box-sizing: border-box;
-    display: inline-block;
-    white-space: nowrap;
     cursor: pointer;
+    display: inline-block;
     position: relative;
     user-select: none;
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Remove white-space property on .mc-toggle__label

GitHub issue number or Jira issue URL: [ID-7139](https://adeo.kanbanize.com/ctrl_board/10/cards/7139/details/)

## Other information
