### PR TITLE
fix(patterns/accordions): set display:flex only if label has an icon

### DIFF
--- a/packages/styles/components/_c.accordion.scss
+++ b/packages/styles/components/_c.accordion.scss
@@ -9,16 +9,15 @@
     @include set-font-scale('06', 'm');
     @include set-font-weight('semi-bold');
 
-    color: $color-font-darker;
-    cursor: pointer;
-    position: relative;
-    padding: $mu125 $mu300 $mu125 $mu050;
-    display: flex;
-    align-items: center;
-    background-image: url(inline-icons('control-more-24',$color-font-darker));
+    background-image: url(inline-icons('control-more-24', $color-font-darker));
     background-position: right $mu050 center;
     background-repeat: no-repeat;
     background-size: $mu150;
+    color: $color-font-darker;
+    cursor: pointer;
+    display: block;
+    position: relative;
+    padding: $mu125 $mu300 $mu125 $mu050;
 
     &:hover {
       background-color: $color-grey-100;
@@ -30,6 +29,11 @@
 
     &--no-padding {
       padding-left: 0;
+    }
+
+    &--icon {
+      display: flex;
+      align-items: center;
     }
   }
 
@@ -56,7 +60,12 @@
 
     &:checked {
       ~ #{$parent}__label {
-        background-image: url(inline-icons('control-less-24', $color-font-darker));
+        background-image:
+          url(
+            inline-icons(
+              'control-less-24',
+              $color-font-darker
+            ));
       }
       ~ #{$parent}__content {
         padding-top: $mu050;
@@ -68,7 +77,12 @@
     &:disabled {
       ~ #{$parent}__label {
         background-color: $color-grey-100;
-        background-image: url(inline-icons('control-more-24', $color-font-light));
+        background-image:
+          url(
+            inline-icons(
+              'control-more-24',
+              $color-font-light
+            ));
         color: $color-font-light;
         cursor: not-allowed;
       }
@@ -80,7 +94,12 @@
 
     &:disabled:checked {
       ~ #{$parent}__label {
-        background-image: url(inline-icons('control-less-24', $color-font-light));
+        background-image:
+          url(
+            inline-icons(
+              'control-less-24',
+              $color-font-light
+            ));
       }
       ~ #{$parent}__content {
         padding-top: $mu050;

--- a/src/docs/Components/Accordion/code.mdx
+++ b/src/docs/Components/Accordion/code.mdx
@@ -56,7 +56,8 @@ Depending on the context of use, the accordion can have several states:
 <Preview path="states" />
 
 ## Variations
-### Padding modifier
+
+### No padding
 
 You have the possibility to have an accordion with no padding.
 
@@ -65,16 +66,19 @@ For this you have to add to the label the `mc-accordion__label--no-padding` modi
 <Preview path="no-padding" />
 
 ### With icon
+
 You can add an icon into any accordions you want.
 
-You only need to add the `mc-accordion__icon` CSS class to your icon.
+For this you have to add to the label the `mc-accordion__label--no-icon` modifier.
+
+Then just add the CSS class `mc-accordion__icon` to your icon.
 
 ```html
 <div class="mc-accordion">
   <input type="checkbox" id="iconUsage" class="mc-accordion__trigger" />
   <label
     for="iconUsage"
-    class="mc-accordion__label mc-accordion__label"
+    class="mc-accordion__label mc-accordion__label mc-accordion__label--icon"
     aria-expand="false"
   >
     <svg class="mc-accordion__icon" xmlns="http://www.w3.org/2000/svg">

--- a/src/docs/Components/Accordion/previews/icon.preview.html
+++ b/src/docs/Components/Accordion/previews/icon.preview.html
@@ -3,7 +3,7 @@
     <input type="checkbox" id="icon" class="mc-accordion__trigger" />
     <label
       for="icon"
-      class="mc-accordion__label mc-accordion__label--with-icon"
+      class="mc-accordion__label mc-accordion__label--icon"
       aria-expand="false"
     >
       <svg class="ku-icon-32 mc-accordion__icon ">
@@ -22,7 +22,7 @@
 </div>
 <svg class="hidden" xmlns="http://www.w3.org/2000/svg">
   <symbol id="Store_StoreLM_32px" viewBox="0 0 32 32">
-    <path 
+    <path
       d="M23 11l-5.59-5.59a2 2 0 00-2.82 0L9 11H5a2 2 0 00-2 2v12a2 2 0 002 2h22a2 2 0 002-2V13a2 2 0 00-2-2zm-3 14h-3.5v-5H20zm-4.5 0H12v-5h3.5zM27 25h-6v-5.5a.5.5 0 00-.5-.5h-9a.5.5 0 00-.5.5V25H5V13h4.83l.58-.59L16 6.83l5.59 5.58.58.59H27z"
     ></path>
     <path

--- a/src/docs/Components/Accordion/previews/no-padding.preview.html
+++ b/src/docs/Components/Accordion/previews/no-padding.preview.html
@@ -1,46 +1,50 @@
 <div class="example">
-    <div class="mc-accordion">
-      <input type="checkbox" id="basic" class="mc-accordion__trigger" />
-      <label for="basic" class="mc-accordion__label mc-accordion__label--no-padding" aria-expand="false">
-        Accordion title
-      </label>
-      <div class="mc-accordion__content">
-        <p>
-          Fusce iaculis dolor nulla, a maximus ipsum sollicitudin et. Ut
-          condimentum at orci aliquam feugiat. Curabitur sagittis placerat leo sit
-          amet pharetra.
-        </p>
-      </div>
+  <div class="mc-accordion">
+    <input type="checkbox" id="basic" class="mc-accordion__trigger" />
+    <label
+      for="basic"
+      class="mc-accordion__label mc-accordion__label--no-padding"
+      aria-expand="false"
+    >
+      Accordion title
+    </label>
+    <div class="mc-accordion__content">
+      <p>
+        Fusce iaculis dolor nulla, a maximus ipsum sollicitudin et. Ut
+        condimentum at orci aliquam feugiat. Curabitur sagittis placerat leo sit
+        amet pharetra.
+      </p>
     </div>
-    <div class="mc-accordion">
-        <input type="checkbox" id="icon" class="mc-accordion__trigger" />
-        <label
-          for="icon"
-          class="mc-accordion__label mc-accordion__label--no-padding"
-          aria-expand="false"
-        >
-          <svg class="ku-icon-32 mc-accordion__icon ">
-            <use href="#Store_StoreLM_32px"></use>
-          </svg>
-          Accordion title
-        </label>
-        <div class="mc-accordion__content">
-          <p>
-            Fusce iaculis dolor nulla, a maximus ipsum sollicitudin et. Ut
-            condimentum at orci aliquam feugiat. Curabitur sagittis placerat leo sit
-            amet pharetra.
-          </p>
-        </div>
-      </div>
   </div>
-  
-  <svg fill="#887f87" class="hidden" xmlns="http://www.w3.org/2000/svg">
-    <symbol id="Store_StoreLM_32px" viewBox="0 0 32 32">
-      <path
-        d="M23 11l-5.59-5.59a2 2 0 00-2.82 0L9 11H5a2 2 0 00-2 2v12a2 2 0 002 2h22a2 2 0 002-2V13a2 2 0 00-2-2zm-3 14h-3.5v-5H20zm-4.5 0H12v-5h3.5zM27 25h-6v-5.5a.5.5 0 00-.5-.5h-9a.5.5 0 00-.5.5V25H5V13h4.83l.58-.59L16 6.83l5.59 5.58.58.59H27z"
-      ></path>
-      <path
-        d="M16.71 10.71a1 1 0 00-1.42 0l-3.58 3.58a1 1 0 00.7 1.71h7.18a1 1 0 00.7-1.71z"
-      ></path>
-    </symbol>
-  </svg>
+  <div class="mc-accordion">
+    <input type="checkbox" id="icon" class="mc-accordion__trigger" />
+    <label
+      for="icon"
+      class="mc-accordion__label mc-accordion__label--no-padding mc-accordion__label--icon"
+      aria-expand="false"
+    >
+      <svg class="ku-icon-32 mc-accordion__icon ">
+        <use href="#Store_StoreLM_32px"></use>
+      </svg>
+      Accordion title
+    </label>
+    <div class="mc-accordion__content">
+      <p>
+        Fusce iaculis dolor nulla, a maximus ipsum sollicitudin et. Ut
+        condimentum at orci aliquam feugiat. Curabitur sagittis placerat leo sit
+        amet pharetra.
+      </p>
+    </div>
+  </div>
+</div>
+
+<svg fill="#887f87" class="hidden" xmlns="http://www.w3.org/2000/svg">
+  <symbol id="Store_StoreLM_32px" viewBox="0 0 32 32">
+    <path
+      d="M23 11l-5.59-5.59a2 2 0 00-2.82 0L9 11H5a2 2 0 00-2 2v12a2 2 0 002 2h22a2 2 0 002-2V13a2 2 0 00-2-2zm-3 14h-3.5v-5H20zm-4.5 0H12v-5h3.5zM27 25h-6v-5.5a.5.5 0 00-.5-.5h-9a.5.5 0 00-.5.5V25H5V13h4.83l.58-.59L16 6.83l5.59 5.58.58.59H27z"
+    ></path>
+    <path
+      d="M16.71 10.71a1 1 0 00-1.42 0l-3.58 3.58a1 1 0 00.7 1.71h7.18a1 1 0 00.7-1.71z"
+    ></path>
+  </symbol>
+</svg>


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Set display:flex only if label has an icon

GitHub issue number or Jira issue URL: #mozaic-support

## Other information
