### PR TITLE
fix(patterns/accordions): update max-height value when accordion is open

### DIFF
--- a/packages/styles/components/_c.accordion.scss
+++ b/packages/styles/components/_c.accordion.scss
@@ -67,9 +67,10 @@
               $color-font-darker
             ));
       }
+
       ~ #{$parent}__content {
         padding-top: $mu050;
-        max-height: 100vh;
+        max-height: none;
         padding-bottom: $mu150;
       }
     }
@@ -86,6 +87,7 @@
         color: $color-font-light;
         cursor: not-allowed;
       }
+
       ~ #{$parent}__content {
         color: $color-font-light;
         cursor: not-allowed;
@@ -101,9 +103,10 @@
               $color-font-light
             ));
       }
+
       ~ #{$parent}__content {
         padding-top: $mu050;
-        max-height: 100vh;
+        max-height: none;
       }
     }
   }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Update max-height value when accordion is open

GitHub issue number or Jira issue URL: From Slack #mozaic-support

## Other information
