### PR TITLE
fix(patterns/notification): remove margin-top on notification message…

### DIFF
--- a/packages/styles/components/_c.notification.scss
+++ b/packages/styles/components/_c.notification.scss
@@ -43,7 +43,8 @@ $notification-close-icon-color: get-token(color, notification, font);
 
   &__title,
   &__message {
-    margin: 0;
+    margin-bottom: 0;
+    margin-top: 0;
   }
 
   &__title {
@@ -51,8 +52,8 @@ $notification-close-icon-color: get-token(color, notification, font);
     @include set-font-scale('05');
   }
 
-  &__message,
-  &__link {
+  &__link,
+  &__title + &__message {
     margin-top: $mu050;
   }
 }


### PR DESCRIPTION
… if no title

## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Remove margin-top on notification message if no title

GitHub issue number or Jira issue URL: N/A

## Other information
