### PR TITLE
fix(patterns/mc-link): avoid the link icon from shrinking

### DIFF
--- a/packages/styles/components/_c.links.scss
+++ b/packages/styles/components/_c.links.scss
@@ -8,6 +8,7 @@
     display: block;
     height: $mu100;
     fill: currentColor;
+    flex-shrink: 0;
     width: $mu100;
 
     &--left {


### PR DESCRIPTION
Fix #684

## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Avoid the link icon from shrinking

GitHub issue number or Jira issue URL: [ISSUE-684](https://github.com/adeo/mozaic-design-system/issues/684)

## Other information
