### PR TITLE
fix(patterns/breadcrumb): adjust breadcrumb behavior on smaller breakpoints

### DIFF
--- a/packages/styles/components/_c.breadcrumb.scss
+++ b/packages/styles/components/_c.breadcrumb.scss
@@ -58,10 +58,13 @@
     @include set-font-scale('04', 'l');
 
     padding-right: $mu050;
-    background-position: left center;
+    background-position: left ($mu025 - 0.0625rem);
     background-repeat: no-repeat;
     background-size: $mu100;
-    flex-shrink: 0;
+
+    @include set-from-screen('l') {
+      flex-shrink: 0;
+    }
 
     &.is-active,
     &:only-child,

--- a/src/docs/Components/Breadcrumb/previews/responsive.preview.html
+++ b/src/docs/Components/Breadcrumb/previews/responsive.preview.html
@@ -11,12 +11,12 @@
           Here is the level 01 link
         </a>
       </li>
-      <li class="mc-breadcrumb__item">
+      <li class="mc-breadcrumb__item is-active">
         <a href="#" class="mc-link">
-          This is another the level (Level 02) link
+          This is another very long level (Level 02) link
         </a>
       </li>
-      <li class="mc-breadcrumb__item is-active">
+      <li class="mc-breadcrumb__item">
         <a href="#" class="mc-link">
           The third level of link is here
         </a>


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Adjust breadcrumb behavior on smaller breakpoints, the arrow must not be centered if the content is on two or more lines.

GitHub issue number or Jira issue URL: N/A

## Other information
