### PR TITLE
fix(patterns/hero): remove unnecessary z-index on hero boxed content

### DIFF
--- a/packages/styles/components/_c.hero.scss
+++ b/packages/styles/components/_c.hero.scss
@@ -81,9 +81,7 @@
 
   &__boxed {
     flex: 100%;
-    position: relative;
     margin-top: -$mu600;
-    z-index: 10;
 
     @include set-from-screen('m') {
       margin-top: -$mu500;


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Remove unnecessary z-index on **.mc-hero__boxed** element

GitHub issue number or Jira issue URL: N/A

## Other information
