### PR TITLE
fix(pattern/qtyselector): remove spin button in mozilla

### DIFF
--- a/packages/styles/settings-tools/_t.reset-forms.scss
+++ b/packages/styles/settings-tools/_t.reset-forms.scss
@@ -16,4 +16,9 @@
       margin: 0;
     }
   }
+
+  /* for mozilla */
+  &[type=number] {
+    -moz-appearance: textfield;
+  }
 }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

<!-- Please describe the current behavior that you are modifying or a link to a relevant issue. -->

GitHub issue number or Jira issue URL: [ISSUE-740](https://github.com/adeo/mozaic-design-system/issues/740)

## Other information
