### PR TITLE
feat(patterns/icons): add arrow-top-16 in sass inline-icons function

### DIFF
--- a/packages/styles/settings-tools/_s.inline-icons.scss
+++ b/packages/styles/settings-tools/_s.inline-icons.scss
@@ -15,6 +15,10 @@
     @return '<svg xmlns="http://www.w3.org/2000/svg" height="1rem" width="1rem" fill="#{$fill}" viewBox="0 0 16 16"><path d="M7.63 11.21a1 1 0 0 1-1.38 0l-2.92-2.6a1 1 0 1 1 1.34-1.48l2.22 2 4.41-4.34a1 1 0 1 1 1.4 1.42z"/></svg>';
   }
 
+  @if $icon == 'arrow-top-16' {
+    @return '<svg xmlns="http://www.w3.org/2000/svg" height="1rem" width="1rem" fill="#{$fill}" viewBox="0 0 16 16"><path d="M2 10.5a1 1 0 01.29-.71l5-5a1 1 0 011.42 0l5 5a1 1 0 01-1.42 1.42L8 6.91l-4.29 4.3a1 1 0 01-1.42 0A1 1 0 012 10.5z"/></svg>';
+  }
+
   @if $icon == 'arrow-left-16' {
     @return '<svg xmlns="http://www.w3.org/2000/svg" height="1rem" width="1rem" viewBox="0 0 16 16" fill="#{$fill}"><path d="M10.5 14a1 1 0 01-.71-.29l-5-5a1 1 0 010-1.42l5-5a1 1 0 111.42 1.42L6.91 8l4.3 4.29a1 1 0 010 1.42 1 1 0 01-.71.29z"/></svg>';
   }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Add arrow-top-16 in sass inline-icons function

GitHub issue number or Jira issue URL: N/A

## Other information
