### PR TITLE
fix(patterns/accordion): a11y - manage focusable elements on closed accordion

### DIFF
--- a/packages/styles/components/_c.accordion.scss
+++ b/packages/styles/components/_c.accordion.scss
@@ -2,6 +2,7 @@
   $parent: &;
 
   background-color: $color-grey-000;
+  border-bottom: get-border(s) solid $color-font-light;
 
   @include set-font-face();
   @include set-accordion-size($accordion-default-size);
@@ -43,13 +44,13 @@
   &__content {
     @include set-font-scale('05', 'm');
 
-    border-bottom: get-border(s) solid $color-font-light;
     color: $color-font-dark;
     height: auto;
     max-height: 0;
     overflow: hidden;
     padding-left: $mu050;
     transition: max-height 0.3s ease-out, padding 0.3s linear;
+    visibility: hidden;
   }
 
   &__trigger {
@@ -61,6 +62,7 @@
         max-height: none;
         padding-top: $mu050;
         padding-bottom: calc(#{$mu150} - #{get-border(s)});
+        visibility: visible;
       }
     }
 

--- a/src/docs/Components/Accordion/previews/stacked.preview.html
+++ b/src/docs/Components/Accordion/previews/stacked.preview.html
@@ -9,6 +9,7 @@
         Fusce iaculis dolor nulla, a maximus ipsum sollicitudin et. Ut
         condimentum at orci aliquam feugiat. Curabitur sagittis placerat leo sit
         amet pharetra.
+        <a href="http://mozaic.adeo.cloud/" class="mc-link">This is a link</a>
       </p>
     </div>
   </div>

--- a/src/docs/Components/Accordion/previews/stacked.preview.scss
+++ b/src/docs/Components/Accordion/previews/stacked.preview.scss
@@ -3,6 +3,7 @@
 @include import-font-families();
 
 @import 'components/_c.accordion';
+@import 'components/_c.links'; // used only for the example
 
 .example {
   margin: $mu125;


### PR DESCRIPTION
Fix #754

## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

**a11y - manage focusable elements on closed accordion**

GitHub issue number or Jira issue URL: **Fix** #754 

## Other information
