### PR TITLE
fix(patterns/card): unify unboxed & outlined cards width on breakpoint M

### DIFF
--- a/packages/styles/components/_c.card.scss
+++ b/packages/styles/components/_c.card.scss
@@ -8,22 +8,22 @@
 
   @include set-font-family();
 
-  max-width: magic-unit-rem(17.75, 'true'); // 284px
+  max-width: magic-unit-rem(17.75, "true"); // 284px
 
-  @include set-from-screen('m') {
-    max-width: magic-unit-rem(14.875, 'true'); // 238px
+  @include set-from-screen("m") {
+    max-width: magic-unit-rem(18.25, "true"); // 292px;
   }
 
-  @include set-from-screen('l') {
-    max-width: magic-unit-rem(18, 'true'); // 288px
+  @include set-from-screen("l") {
+    max-width: magic-unit-rem(18, "true"); // 288px
   }
 
-  @include set-from-screen('xl') {
-    max-width: magic-unit-rem(17.5, 'true'); // 280px
+  @include set-from-screen("xl") {
+    max-width: magic-unit-rem(17.5, "true"); // 280px
   }
 
-  @include set-from-screen('xxl') {
-    max-width: magic-unit-rem(27.25, 'true'); // 436px
+  @include set-from-screen("xxl") {
+    max-width: magic-unit-rem(27.25, "true"); // 436px
   }
 
   &__visual {
@@ -34,11 +34,11 @@
     &::before {
       @include ratio-before();
 
-      padding-top: map-get($card-visual-ratios, '4x3');
+      padding-top: map-get($card-visual-ratios, "4x3");
     }
 
     @each $ratio, $size in $card-visual-ratios {
-      @if ($ratio != '4x3') {
+      @if ($ratio != "4x3") {
         &--#{$ratio}::before {
           padding-top: $size;
         }
@@ -66,21 +66,22 @@
   }
 
   &__title {
-    @include set-font-scale('06', 'm');
-    @include set-font-weight('semi-bold');
+    @include set-font-scale("06", "m");
+    @include set-font-weight("semi-bold");
 
     color: $color-font-darkest;
   }
 
   &__subtitle {
-    @include set-font-scale('04', 'm');
-    @include set-font-weight('regular');
+    @include set-font-scale("04", "m");
+    @include set-font-weight("regular");
 
     color: $color-font-dark;
   }
 
   &__body {
-    @include set-font-scale('05', 'm');
+    @include set-font-scale("05", "m");
+
     color: $color-font-darker;
     margin-bottom: $mu100;
   }
@@ -90,10 +91,6 @@
     border: get-border(m) solid $color-font-darker;
     border-radius: $mu025;
     overflow: hidden;
-
-    @media (min-width: $screen-m) and (max-width: ($screen-l - 1)) {
-      max-width: magic-unit-rem(18.25, 'true'); // 292px;
-    }
 
     #{$parent} {
       &__content {

--- a/packages/styles/components/_c.card.scss
+++ b/packages/styles/components/_c.card.scss
@@ -1,5 +1,5 @@
 .mc-card {
-  $parent: &;
+  $parent: get-parent-selector(&);
 
   &,
   * {


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

**Unify unboxed & outlined cards width on breakpoint M**

GitHub issue number or Jira issue URL: N/A

## Other information
