### PR TITLE
fix(pattern/tabs): add a pointer-events on tabs dropdown variation

### DIFF
--- a/packages/styles/components/_c.tabs.scss
+++ b/packages/styles/components/_c.tabs.scss
@@ -18,6 +18,7 @@
     content: "";
     display: block;
     left: 0;
+    pointer-events: none;
     position: absolute;
     right: 0;
     top: 0;
@@ -65,6 +66,7 @@
   &__link {
     @include set-font-face();
     @include set-font-scale("05", "s");
+
     @include set-focus-floating-base {
       bottom: -($mu025/2);
       top: -($mu025/2);


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

On the dropdown navigation implementation of the tabs component, the `::before` pseudo-element element the use of the select.

Can see this behaviour on this link : https://adeo.github.io/mozaic-vue/?path=/story/components-mtab--showcase


GitHub issue number or Jira issue URL: N/A

## Other information
