### PR TITLE
feat(progressbar): indeterminate support

### DIFF
--- a/packages/styles/components/_c.progressbar.scss
+++ b/packages/styles/components/_c.progressbar.scss
@@ -24,6 +24,26 @@
     transition: width 0.4s ease;
     top: 0;
 
+    &-indeterminate {
+      width: 100%;
+      animation: running-progress 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+
+      @keyframes running-progress {
+        0% {
+          margin-left: 0px;
+          margin-right: 100%;
+        }
+        50% {
+          margin-left: 25%;
+          margin-right: 0%;
+        }
+        100% {
+          margin-left: 100%;
+          margin-right: 0;
+        }
+      }
+    }
+
     @at-root #{$parent}--static & {
       transition: none;
     }

--- a/src/docs/Components/ProgressBar/index.mdx
+++ b/src/docs/Components/ProgressBar/index.mdx
@@ -44,3 +44,15 @@ The percentage progress bar version is used when you need to tell the exact prog
 Please note that you will have to change the font-color from `G900` to `G000` when the progress is more than 51%.
 
 </Highlight>
+
+### Indeterminate mode
+
+The indeterminate mode version is used when you cannot know progression or total time of an action.
+
+<Preview path="percentage" nude />
+
+<Highlight theme="warning">
+
+The `width` style on tag `mc-progressbar__indicator` must not be fixed.
+
+</Highlight>

--- a/src/docs/Components/ProgressBar/previews/indeterminate.preview.html
+++ b/src/docs/Components/ProgressBar/previews/indeterminate.preview.html
@@ -1,0 +1,10 @@
+<div class="example">
+  <div class="mc-progressbar">
+    <div
+      class="mc-progressbar__indicator-indeterminate"
+      role="progressbar"
+    >
+      &nbsp;
+    </div>
+  </div>
+</div>

--- a/src/docs/Components/ProgressBar/previews/indeterminate.preview.scss
+++ b/src/docs/Components/ProgressBar/previews/indeterminate.preview.scss
@@ -1,0 +1,10 @@
+@import 'settings-tools/_all-settings';
+
+@include import-font-families();
+
+@import 'components/_c.progressbar';
+
+.example {
+  padding: $mu200;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [ ] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

<!-- Please describe the current behavior that you are modifying or a link to a relevant issue. -->

I have to use a loader, but in an *indeterminate* mode.
I propose this feature 👼

## Other information

`animation` can be customized as you prefer 😉