### PR TITLE
refactor(patterns/modal): standardize common code between layer and modal

### DIFF
--- a/packages/styles/components/_c.layer.scss
+++ b/packages/styles/components/_c.layer.scss
@@ -2,20 +2,11 @@
   $parent: get-parent-selector(&);
 
   @include set-font-face();
+  @include set-dialog-base();
 
-  box-sizing: border-box;
-  bottom: 0;
   display: flex;
   justify-content: flex-end;
-  left: 0;
-  outline: 0;
   overflow: hidden;
-  pointer-events: none;
-  position: fixed;
-  right: 0;
-  top: 0;
-  width: 100%;
-  z-index: 1999999999; // To get the layer on top of Mopinion.
 
   * {
     box-sizing: inherit;
@@ -227,25 +218,6 @@
   }
 
   &-overlay {
-    background-color: rgba($color-grey-900, 0.7);
-    bottom: 0;
-    cursor: pointer;
-    display: block;
-    filter: blur(1px);
-    left: 0;
-    opacity: 0;
-    position: fixed;
-    pointer-events: none;
-    right: 0;
-    top: 0;
-    transition: opacity 0.4s ease, visibility 0ms 0.4s;
-    z-index: 1999999998;
-
-    &.is-visible {
-      opacity: 1;
-      pointer-events: all;
-      transition: opacity 0.4s ease, visibility 0ms;
-      visibility: visible;
-    }
+    @include set-dialog-overlay();
   }
 }

--- a/packages/styles/components/_c.modal.scss
+++ b/packages/styles/components/_c.modal.scss
@@ -2,21 +2,14 @@
   $parent: get-parent-selector(&);
 
   @include set-font-face();
+  @include set-dialog-base();
 
-  box-sizing: border-box;
-  display: flex;
   align-items: flex-end;
+  display: flex;
   justify-content: center;
-  height: 100%;
-  left: 0;
-  outline: 0;
-  padding: $mu100 magic-unit-rem(1.125, true);
-  position: fixed;
-  top: 0;
-  width: 100%;
-  z-index: 1999999999;
   overflow-x: hidden;
   overflow-y: auto;
+  padding: $mu100 magic-unit-rem(1.125, true);
 
   @include set-from-screen(m) {
     align-items: center;
@@ -90,7 +83,8 @@
     flex-shrink: 0;
     height: $mu200;
     width: $mu200;
-    background: transparent
+    background:
+      transparent
       url(inline-icons("control-cross-32", $color-grey-500)) no-repeat;
     background-size: contain;
 
@@ -181,13 +175,6 @@
   }
 
   &-overlay {
-    filter: blur(1px);
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    background-color: rgba($color-grey-900, 0.7);
-    z-index: 1999999998;
+    @include set-dialog-overlay();
   }
 }

--- a/packages/styles/settings-tools/_all-settings.scss
+++ b/packages/styles/settings-tools/_all-settings.scss
@@ -39,3 +39,4 @@
 @import "./_s.accordions.scss";
 @import "./_s.card.scss";
 @import "./_s.stepper";
+@import "./_s.modal";

--- a/packages/styles/settings-tools/_s.modal.scss
+++ b/packages/styles/settings-tools/_s.modal.scss
@@ -1,0 +1,33 @@
+@mixin set-dialog-base() {
+  box-sizing: border-box;
+  bottom: 0;
+  left: 0;
+  outline: 0;
+  pointer-events: none;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 1999999999; // Position the dialog above the MOpinion element
+}
+
+@mixin set-dialog-overlay() {
+  background-color: rgba($color-grey-900, 0.7);
+  bottom: 0;
+  cursor: pointer;
+  filter: blur(1px);
+  left: 0;
+  opacity: 0;
+  position: fixed;
+  pointer-events: none;
+  right: 0;
+  top: 0;
+  transition: opacity 0.4s ease, visibility 0ms 0.4s;
+  z-index: 1999999998;
+
+  &.is-visible {
+    opacity: 1;
+    pointer-events: all;
+    transition: opacity 0.4s ease, visibility 0ms;
+    visibility: visible;
+  }
+}


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

 Create and use Sass mixins to standardize the common code between the layer and modal components
