### PR TITLE
refactor(patterns/modal): set pointer-events only when open

### DIFF
--- a/packages/styles/components/_c.layer.scss
+++ b/packages/styles/components/_c.layer.scss
@@ -19,7 +19,6 @@
     height: 100%;
     max-width: calc(100% - #{$mu200});
     padding-bottom: $mu100;
-    pointer-events: all;
     transform: translateX(100%);
     transition: transform 0.4s ease;
     width: 100%;
@@ -38,6 +37,7 @@
     }
 
     &.is-open {
+      pointer-events: all;
       transform: translateX(0);
     }
 

--- a/packages/styles/components/_c.modal.scss
+++ b/packages/styles/components/_c.modal.scss
@@ -21,7 +21,6 @@
     display: flex;
     flex-direction: column;
     opacity: 0;
-    pointer-events: all;
     position: relative;
     transform: translateY(-25%);
     transition: transform 0.4s ease, opacity 0.4s ease;
@@ -48,6 +47,7 @@
 
     &.is-open {
       opacity: 1;
+      pointer-events: all;
       transform: translateY(0);
     }
   }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Set 'pointer-events:all' only when dialog is opened