### PR TITLE
refactor(patterns/phonenumberinput): remove the use of .mc-field__input on input tag

### DIFF
--- a/src/docs/Components/Form/PhoneNumberInput/code.mdx
+++ b/src/docs/Components/Form/PhoneNumberInput/code.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Code'
+title: "Code"
 order: 2
 ---
 
@@ -8,16 +8,17 @@ order: 2
 Import **the settings**, the **text-input** and the **phone-number** scss files.
 
 ```scss
-@import 'settings-tools/_all-settings';
-@import 'components/_c.text-input';
-@import 'components/_c.phone-number';
+@import "settings-tools/_all-settings";
+@import "components/_c.text-input";
+@import "components/_c.phone-number";
 ```
 
 # Usage
-A phone number input is composed of 2 main zones: 
 
-- *A dropdown* with the class : `mc-phone-number__dropdown`
-- *A number input * with the class : `mc-phone-number__input`
+A phone number input is composed of 2 main zones:
+
+- _A dropdown_ with the class : `mc-phone-number__dropdown`
+- _A number input _ with the class : `mc-phone-number__input`
 
 ```html
 <div class="mc-phone-number">
@@ -35,7 +36,7 @@ A phone number input is composed of 2 main zones:
       <span class="mc-phone_number__indicator">+33</span>
     </button>
     <ul
-    id="phone_number_list"
+      id="phone_number_list"
       tabindex="-1"
       role="listbox"
       aria-labelledby="phone_number_list"
@@ -52,7 +53,7 @@ A phone number input is composed of 2 main zones:
   </div>
   <input
     type="text"
-    class="mc-phone-number__input mc-text-input mc-text-input--m mc-field__input"
+    class="mc-phone-number__input mc-text-input mc-text-input--m"
     id="smallField"
     placeholder="00 00 00 00 00"
     name="example-small"
@@ -63,38 +64,50 @@ A phone number input is composed of 2 main zones:
 <Preview path="basic" />
 
 # Detail of areas
-## Dropdown
-The dropdown contains: 
- - The dropdown trigger (`mc-phone-number__button`)
- - The list of the countries available (`mc-phone-number__list`)
 
-Each element of list contains: 
- - The country flag (`mc-phone-number__flag`)
- - The country name (`mc-phone-number__country`)
- - The country indicator (`mc-phone-number__country`)
+## Dropdown
+
+The dropdown contains:
+
+- The dropdown trigger (`mc-phone-number__button`)
+- The list of the countries available (`mc-phone-number__list`)
+
+Each element of list contains:
+
+- The country flag (`mc-phone-number__flag`)
+- The country name (`mc-phone-number__country`)
+- The country indicator (`mc-phone-number__country`)
 
 # Variation
+
 ## With label
 
 When using a phone number input with a label, you must make sure to import the fields.scss file in addition to the others:
 
 ```scss
-@import 'settings-tools/_all-settings'; 
-@import 'components/_c.text-input'; 
-@import 'components/_c.fields'; 
-@import 'components/_c.phone-number';
+@import "settings-tools/_all-settings";
+@import "components/_c.text-input";
+@import "components/_c.fields";
+@import "components/_c.phone-number";
 ```
 
 <Preview path="label" />
 
 # Javascript behaviour
+
 <Highlight theme="tips">
 The javascript to manage the dropdown is based on the listbox from <a href="https://www.w3.org/TR/2019/NOTE-wai-aria-practices-1.1-20190814/examples/listbox/listbox-collapsible.html">W3C</a><br />
 
 To have a fully fonctionnal phone number input, make sure to add the following script to your code.
 
-<a href="https://www.w3.org/TR/2019/NOTE-wai-aria-practices-1.1-20190814/examples/listbox/js/listbox.js">listbox.js</a><br />
-<a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/js/utils.js">utils.js</a>
+<a href="https://www.w3.org/TR/2019/NOTE-wai-aria-practices-1.1-20190814/examples/listbox/js/listbox.js">
+  listbox.js
+</a>
+<br />
+<a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/js/utils.js">
+  utils.js
+</a>
 
 On the dropdown opening add the `mc-phone-number--focused` class and remove the `mc-phone-number__list--hidden` class.
+
 </Highlight>

--- a/src/docs/Components/Form/PhoneNumberInput/previews/label.preview.html
+++ b/src/docs/Components/Form/PhoneNumberInput/previews/label.preview.html
@@ -10,7 +10,7 @@
     <div class="example">
       <div class="mc-field">
         <label class="mc-field__label" for="default"> Label </label>
-        <div id="mc-phone-number" class="mc-phone-number mc-field__input">
+        <div id="mc-phone-number" class="mc-phone-number mc-field__element">
           <div class="mc-phone-number__dropdown">
             <button
               type="button"


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

**Remove the use of .mc-field__input on input tag**