### PR TITLE
fix(patterns/modal): add visibility: hidden on closed modal

### DIFF
--- a/packages/styles/components/_c.modal.scss
+++ b/packages/styles/components/_c.modal.scss
@@ -186,4 +186,8 @@
   &-overlay {
     @include set-dialog-overlay();
   }
+
+  &.is-hidden {
+    visibility: hidden;
+  }
 }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Add `visibility: hidden` on closed modal

GitHub issue number or Jira issue URL:
- Problem reported through the issue #863
- Problem finally corrected via PR #855 
