### PR TITLE
fix(patterns/tabs): set font-weight to semi-bold for the active tab

### DIFF
--- a/packages/styles/components/_c.tabs.scss
+++ b/packages/styles/components/_c.tabs.scss
@@ -17,7 +17,7 @@
   &::before {
     bottom: 0;
     box-shadow: 0 $mu025 $mu025 rgba($color-tabs-shadow, 0.1);
-    content: "";
+    content: '';
     display: block;
     left: 0;
     pointer-events: none;
@@ -67,7 +67,7 @@
 
   &__link {
     @include set-font-face();
-    @include set-font-scale("05", "s");
+    @include set-font-scale('05', 's');
 
     @include set-focus-floating-base {
       bottom: -(math.div($mu025, 2));
@@ -86,6 +86,8 @@
 
     &:active,
     &--selected {
+      @include set-font-weight('semi-bold');
+
       color: $color-tabs-active;
     }
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Change the text of the active tab for semi-bold style.

=> https://jira.adeo.com/browse/MZC-125