### PR TITLE
refactor(patterns/breadcrumb): fix CSS class mc-link typo

### DIFF
--- a/packages/styles/components/_c.breadcrumb.scss
+++ b/packages/styles/components/_c.breadcrumb.scss
@@ -86,7 +86,7 @@
 
   &__current {
     &,
-    &.m-link {
+    &.mc-link {
       cursor: default;
       text-decoration: none;
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Fix CSS class mc-link typo