### PR TITLE
fix(patterns/layer): make the layer's shadow unclickable

### DIFF
--- a/packages/styles/components/_c.layer.scss
+++ b/packages/styles/components/_c.layer.scss
@@ -142,6 +142,7 @@
           );
         bottom: 0;
         position: absolute;
+        pointer-events: none;
         height: 1.875rem;
         left: 0;
         right: 0;


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Make the layer's shadow unclickable

GitHub issue number or Jira issue URL: https://github.com/adeo/mozaic-vue/issues/348