### PR TITLE
fix(tokens/tabs): use primary colors tokens for the tab component

### DIFF
--- a/packages/tokens/build/js/tokensObject.js
+++ b/packages/tokens/build/js/tokensObject.js
@@ -6373,7 +6373,7 @@ module.exports = {
         "filePath": "packages/tokens/properties/color/tabs.json",
         "isSource": true,
         "original": {
-          "value": "{color.font.success.value}"
+          "value": "{color.primary-01.600.value}"
         },
         "name": "ColorTabsHover",
         "attributes": {

--- a/packages/tokens/properties/color/tabs.json
+++ b/packages/tokens/properties/color/tabs.json
@@ -11,7 +11,7 @@
         "value": "{color.font.darker.value}"
       },
       "hover": {
-        "value": "{color.font.success.value}"
+        "value": "{color.primary-01.600.value}"
       },
       "disabled": {
         "value": "{color.font.light.value}"


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Use primary colors tokens for the tab component
