### PR TITLE
fix(tools/autoprefixer): fix wrong removal of cssnano when autoprefixer is disabled

### DIFF
--- a/packages/css-dev-tools/postcssPluginConfig.js
+++ b/packages/css-dev-tools/postcssPluginConfig.js
@@ -72,7 +72,7 @@ const productionPlugins = [
 ]
 
 if (CM.getKey('autoprefixer.disabled')) {
-  productionPlugins.splice(3,1);
+  productionPlugins.splice(4,1);
 }
 
 if(CM.getKey('purgecss')) {


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [X] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [X] No

## Describe the changes

Error on the postCSS plugin configuration for production, when `autoprefixr.disabled` is true, it removes `cssnano`

GitHub issue number or Jira issue URL: N/A

## Other information
