### PR TITLE
refactor(onboard): remove import-font-families from preview docs & components

### DIFF
--- a/src/docs/Components/Badge/code.mdx
+++ b/src/docs/Components/Badge/code.mdx
@@ -5,11 +5,10 @@ order: 2
 
 ## Import
 
-Import the settings, the font families mixin and the badge `scss` files.
+Import the settings and the badge `scss` files.
 
 ```scss
 @import 'settings-tools/_all-settings';
-@include import-font-families();
 @import 'components/_c.badge';
 ```
 

--- a/src/docs/Components/Breadcrumb/code.mdx
+++ b/src/docs/Components/Breadcrumb/code.mdx
@@ -12,8 +12,6 @@ Import **the settings**, **the link** and **the breadcrumb** scss files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.links';
 
 @import 'components/_c.breadcrumb';

--- a/src/docs/Components/Buttons/code.mdx
+++ b/src/docs/Components/Buttons/code.mdx
@@ -8,8 +8,6 @@ order: 2
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.button';
 ```
 

--- a/src/docs/Components/Cards/code.mdx
+++ b/src/docs/Components/Cards/code.mdx
@@ -12,8 +12,6 @@ In addition to the basic files listed above, you must also import the `_c.button
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.button'; // optional
 @import 'components/_c.links'; // optional
 @import 'components/_c.card';
@@ -98,8 +96,6 @@ When using a link in a card, you must make sure to perform the following scss im
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.links';
 @import 'components/_c.card';
 ```
@@ -122,8 +118,6 @@ When using a button in a card, you must make sure to perform the following scss 
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 @import 'components/_c.button';
 @import 'components/_c.card';

--- a/src/docs/Components/Flags/code.mdx
+++ b/src/docs/Components/Flags/code.mdx
@@ -5,11 +5,10 @@ order: 2
 
 ## Import
 
-Import the settings, the font families mixin and the flag `scss` files.
+Import the settings and the flag `scss` files.
 
 ```scss
 @import 'settings-tools/_all-settings';
-@include import-font-families();
 @import 'components/_c.flag';
 ```
 

--- a/src/docs/Components/Form/Checkbox/code.mdx
+++ b/src/docs/Components/Form/Checkbox/code.mdx
@@ -12,8 +12,6 @@ Import **the settings** and **the checkbox** `scss` files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.checkbox';
 ```
 
@@ -56,8 +54,6 @@ Import **the settings**, **the checkbox** and **the fields** scss files.
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 @import 'components/_c.checkbox';
 

--- a/src/docs/Components/Form/Datepicker/code.mdx
+++ b/src/docs/Components/Form/Datepicker/code.mdx
@@ -10,8 +10,6 @@ Import the **settings**, the **text-input** and the **field** `scss` files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.text-input';
 
 @import 'components/_c.fields';

--- a/src/docs/Components/Form/Field/code.mdx
+++ b/src/docs/Components/Form/Field/code.mdx
@@ -10,8 +10,6 @@ Import the settings, the text-input and the fields `scss` files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.text-input';
 
 @import 'components/_c.fields';

--- a/src/docs/Components/Form/FileUploader/code.mdx
+++ b/src/docs/Components/Form/FileUploader/code.mdx
@@ -12,8 +12,6 @@ Import **the settings** and **the file uploader** `scss` files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.file-uploader';
 ```
 
@@ -95,8 +93,6 @@ Import **the settings**, **the file uploader** and **the fields** scss files.
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 @import 'components/_c.file-uploader';
 

--- a/src/docs/Components/Form/PasswordInput/code.mdx
+++ b/src/docs/Components/Form/PasswordInput/code.mdx
@@ -10,8 +10,6 @@ Import the **settings**, the **text-input**, the **password-input** and the **fi
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.text-input';
 @import 'components/_c.password-input';
 @import 'components/_c.fields';

--- a/src/docs/Components/Form/Radio/code.mdx
+++ b/src/docs/Components/Form/Radio/code.mdx
@@ -12,8 +12,6 @@ Import **the settings** and **the radio** `scss` files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.radio';
 ```
 
@@ -52,8 +50,6 @@ Import **the settings**, **the radio** and **the fields** scss files.
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 @import 'components/_c.radio';
 

--- a/src/docs/Components/Form/Select/code.mdx
+++ b/src/docs/Components/Form/Select/code.mdx
@@ -12,8 +12,6 @@ Import **the settings**, **the select** and **the fields** scss files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.select';
 
 @import 'components/_c.fields';
@@ -146,8 +144,6 @@ In some cases you may need to use the select field outside of a form. To do this
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 @import 'components/_c.select';
 ```

--- a/src/docs/Components/Form/TextArea/code.mdx
+++ b/src/docs/Components/Form/TextArea/code.mdx
@@ -13,8 +13,6 @@ Import **the settings**, **the text area** and **the fields** scss files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.textarea';
 
 @import 'components/_c.fields';
@@ -137,8 +135,6 @@ In some cases you may need to use the text field outside of a form. To do this, 
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 @import 'components/_c.textarea';
 ```

--- a/src/docs/Components/Form/TextInput/code.mdx
+++ b/src/docs/Components/Form/TextInput/code.mdx
@@ -10,8 +10,6 @@ Import the **settings**, the **text-input** and the **field** `scss` files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.text-input';
 
 @import 'components/_c.fields';
@@ -98,8 +96,6 @@ To add a left icon, you need to import `components/_c.left-icon-input` after the
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 @import 'components/_c.text-input';
 @import 'components/_c.left-icon-input';

--- a/src/docs/Components/Form/Toggle/code.mdx
+++ b/src/docs/Components/Form/Toggle/code.mdx
@@ -12,8 +12,6 @@ Import **the settings** and **the toggle** `scss` files.
 ```scss
 @import "settings-tools/_all-settings";
 
-@include import-font-families();
-
 @import "components/_c.toggle";
 ```
 
@@ -115,8 +113,6 @@ Import **the settings**, **the toggle** and **the fields** scss files.
 
 ```scss
 @import "settings-tools/_all-settings";
-
-@include import-font-families();
 
 @import "components/_c.toggle";
 

--- a/src/docs/Components/Hero/code.mdx
+++ b/src/docs/Components/Hero/code.mdx
@@ -8,8 +8,6 @@ order: 2
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'typography/_t.all-base-typography';
 @import 'layouts/_l.container';
 @import 'layouts/_l.flexy';

--- a/src/docs/Components/Layers/code.mdx
+++ b/src/docs/Components/Layers/code.mdx
@@ -12,8 +12,6 @@ Import the **settings**, the **layer**, and the **button** scss files.
 ```scss
 @import "settings-tools/_all-settings";
 
-@include import-font-families();
-
 @import "components/_c.layer";
 @import "components/_c.button";
 ```

--- a/src/docs/Components/Links/code.mdx
+++ b/src/docs/Components/Links/code.mdx
@@ -10,8 +10,6 @@ Import the settings and the links `scss` files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.links';
 ```
 

--- a/src/docs/Components/Modals/code.mdx
+++ b/src/docs/Components/Modals/code.mdx
@@ -12,8 +12,6 @@ Import the **settings**, the **modal**, the **bodys**, and the **button** scss f
 ```scss
 @import "settings-tools/_all-settings";
 
-@include import-font-families();
-
 @import "typography/_t.bodys";
 @import "components/_c.modal";
 @import "components/_c.button";

--- a/src/docs/Components/ProgressBar/code.mdx
+++ b/src/docs/Components/ProgressBar/code.mdx
@@ -8,8 +8,6 @@ order: 2
 ```scss
 @import "settings-tools/_all-settings";
 
-@include import-font-families();
-
 @import "components/_c.progressbar";
 ```
 

--- a/src/docs/Components/Stepper/code.mdx
+++ b/src/docs/Components/Stepper/code.mdx
@@ -10,8 +10,6 @@ Import **the settings** and **the stepper** scss files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.stepper';
 ```
 

--- a/src/docs/Components/Tabs/code.mdx
+++ b/src/docs/Components/Tabs/code.mdx
@@ -14,8 +14,6 @@ Import **the settings** and **the tabs** `scss` files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.tabs';
 ```
 
@@ -167,8 +165,6 @@ To do this, you just need to use the [Mozaic Select component](/Components/Form/
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 @import 'components/_c.tabs';
 @import 'components/_c.select';

--- a/src/docs/Components/Tag/code.mdx
+++ b/src/docs/Components/Tag/code.mdx
@@ -7,7 +7,6 @@ order: 2
 
 ```scss
 @import 'settings-tools/_all-settings';
-@include import-font-families();
 @import 'components/_c.tag';
 ```
 

--- a/src/docs/Components/Tooltip/code.mdx
+++ b/src/docs/Components/Tooltip/code.mdx
@@ -16,8 +16,6 @@ Import **the settings** and **the tooltip** `scss` files.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'components/_c.tooltip';
 ```
 

--- a/src/docs/Foundations/Layout/Grid/code.mdx
+++ b/src/docs/Foundations/Layout/Grid/code.mdx
@@ -12,8 +12,6 @@ order: 1
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'layouts/_l.container'; // you generally want the container as well
 @import 'layouts/_l.flexy';
 ```

--- a/src/docs/Foundations/Layout/Grid/customization.mdx
+++ b/src/docs/Foundations/Layout/Grid/customization.mdx
@@ -31,8 +31,6 @@ Example: Create a blog post layout with an image and a text. From tablet screens
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 .post-item {
   $gutter: $mu200;
   /* set flex */
@@ -125,8 +123,6 @@ then import it in your main bundle
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 ...
 @import 'layouts/_l.flexy';

--- a/src/docs/Foundations/Typography/BodyStyles/code.mdx
+++ b/src/docs/Foundations/Typography/BodyStyles/code.mdx
@@ -12,8 +12,6 @@ You can import all base typography scss files by importing the `_a.all-base-typo
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'typography/_t.all-base-typography';
 ```
 
@@ -26,8 +24,6 @@ You can import all base typography scss files by importing the `_a.all-base-typo
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 @import 'typography/_t.bodys';
 ```

--- a/src/docs/Foundations/Typography/Colors/code.mdx
+++ b/src/docs/Foundations/Typography/Colors/code.mdx
@@ -10,8 +10,6 @@ Use the `font-color()` mixin to set an othorized text color to an element.
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 .example-text {
   @include set-color('dark');
   // is equivalent to :

--- a/src/docs/Foundations/Typography/HeadingStyles/code.mdx
+++ b/src/docs/Foundations/Typography/HeadingStyles/code.mdx
@@ -7,7 +7,6 @@ order: 2
 
 ```scss
 @import 'settings-tools/_all-settings';
-@include import-font-families();
 @import 'typography/_t.headings';
 ```
 

--- a/src/docs/Foundations/Typography/HeroStyles/code.mdx
+++ b/src/docs/Foundations/Typography/HeroStyles/code.mdx
@@ -12,8 +12,6 @@ You can import all base typography scss files by importing the `_a.all-base-typo
 ```scss
 @import 'settings-tools/_all-settings';
 
-@include import-font-families();
-
 @import 'typography/_t.all-base-typography';
 ```
 
@@ -27,8 +25,6 @@ You can import all base typography scss files by importing the `_a.all-base-typo
 
 ```scss
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 
 @import 'typography/_t.heros';
 ```

--- a/src/docs/Foundations/Utilities/BorderRadius/code.mdx
+++ b/src/docs/Foundations/Utilities/BorderRadius/code.mdx
@@ -10,8 +10,6 @@ In order to use the border-radius values provided by Mozaic, you have to import 
 ```scss
 // mandatory
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
 ```
 
 ## Basic usage

--- a/src/docs/Foundations/Utilities/Shadows/code.mdx
+++ b/src/docs/Foundations/Utilities/Shadows/code.mdx
@@ -10,9 +10,6 @@ To get the `set-box-shadow()` mixin, you need to import `_all-settings.scss`.
 ```scss
 // mandatory
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
-
 ```
 
 ## Basic usage

--- a/src/docs/Foundations/Utilities/Strokes/code.mdx
+++ b/src/docs/Foundations/Utilities/Strokes/code.mdx
@@ -10,9 +10,6 @@ To get the `get-border ()` function you need to import `_all-settings.scss`.
 ```scss
 // mandatory
 @import 'settings-tools/_all-settings';
-
-@include import-font-families();
-
 ```
 
 ## Basic usage


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Remove import-font-families from preview docs & components

Resolves #938
