### PR TITLE
fix(component/button): ensure that the buttons with icons keep the right height

### DIFF
--- a/packages/styles/components/_c.button.scss
+++ b/packages/styles/components/_c.button.scss
@@ -40,6 +40,7 @@
 
   &--square {
     align-items: center;
+    height: 0;
     padding: 0;
   }
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Ensure that the buttons with icons keep the right height