### PR TITLE
fix(component/accordion): allow title to go to line on small screens

### DIFF
--- a/packages/styles/components/_c.accordion.scss
+++ b/packages/styles/components/_c.accordion.scss
@@ -122,7 +122,7 @@
     @include set-font-weight("semi-bold");
 
     color: $color-font-darker;
-    flex: 1 0 auto;
+    width: 100%;
     margin: {
       top: 0;
       bottom: 0;
@@ -150,6 +150,7 @@
     align-items: center;
     gap: $mu050;
     padding-left: $mu050;
+    text-align: left;
     width: 100%;
 
     &:focus {

--- a/src/docs/Components/Accordion/previews/stacked.preview.html
+++ b/src/docs/Components/Accordion/previews/stacked.preview.html
@@ -55,6 +55,36 @@
       </p>
     </div>
   </div>
+
+  <div class="mc-accordion">
+    <div class="mc-accordion__header">
+      <h2 class="mc-accordion__title">
+        <button
+          id="accordion3"
+          class="mc-accordion__trigger"
+          aria-controls="content3"
+          aria-expanded="false"
+          data-mc-component="accordion"
+        >
+          Here is an accordion with a very very very long text that can extend
+          over several lines on small screens.
+        </button>
+      </h2>
+    </div>
+    <div
+      id="content3"
+      class="mc-accordion__content"
+      aria-hidden="true"
+      aria-labelledby="accordion3"
+    >
+      <p>
+        Fusce iaculis dolor nulla, a maximus ipsum sollicitudin et. Ut
+        condimentum at orci aliquam feugiat. Curabitur sagittis placerat leo sit
+        amet pharetra.
+        <a href="http://mozaic.adeo.cloud/" class="mc-link">This is a link</a>
+      </p>
+    </div>
+  </div>
 </div>
 
 <script>


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Allow title to go to line on small screens