### PR TITLE
chore(gatsby): upgrade Gatsby to latest v3 version before v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "adm-zip": "^0.5.9",
     "chromedriver": "^97.0.0",
     "core-js": "^3.18.3",
-    "gatsby": "^3.14.4",
+    "gatsby": "^3.14.6",
     "gatsby-plugin-google-analytics": "^3.14.0",
     "glob": "^7.2.0",
     "react": "^17.0.2",

--- a/packages/gatsby-source-preview/gatsby-node.js
+++ b/packages/gatsby-source-preview/gatsby-node.js
@@ -147,7 +147,7 @@ exports.sourceNodes = (tools, configOptions) => {
     // It's possible the file node was never created as sometimes tools will
     // write and then immediately delete temporary files to the file system.
     if (node) {
-      deleteNode({ node })
+      deleteNode(node)
     }
   }
 
@@ -178,7 +178,7 @@ exports.sourceNodes = (tools, configOptions) => {
     const node = getNode(createNodeId(path))
 
     if (node) {
-      deleteNode({ node })
+      deleteNode(node)
     }
   })
 

--- a/packages/gatsby-theme-styleguide/package.json
+++ b/packages/gatsby-theme-styleguide/package.json
@@ -10,7 +10,7 @@
     "@mozaic-ds/gatsby-github-release": "^1.14.0",
     "@mozaic-ds/gatsby-source-preview": "^1.20.0",
     "babel-plugin-styled-components": "^1.13.2",
-    "gatsby": "^3.9.1",
+    "gatsby": "^3.14.6",
     "gatsby-plugin-flexsearch": "^1.0.3",
     "gatsby-plugin-mdx": "^2.14.0",
     "gatsby-plugin-react-helmet": "^4.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9088,7 +9088,7 @@ gatsby-worker@^0.5.0:
     "@babel/core" "^7.15.5"
     "@babel/runtime" "^7.15.4"
 
-gatsby@^3.14.4, gatsby@^3.9.1:
+gatsby@^3.14.6:
   version "3.14.6"
   resolved "https://registry.npmjs.org/gatsby/-/gatsby-3.14.6.tgz#b05769f27ccccaf90c7c5b483a7d11bf74f45101"
   integrity sha512-H9IOoqkyzu0gEDzLUcm7pGSgwJbR338z+fjp4NsLlE4DkkA2T4H6nWRXLYoDwtNC+X2wfWSrwX8ui2wosAmQOQ==


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [ ] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [ ] No

## Describe the changes

Upgrade Gatsby to latest v3 version before v4