### PR TITLE
docs: fix typo in TextArea/code.mdx

### DIFF
--- a/src/docs/Components/Form/TextArea/code.mdx
+++ b/src/docs/Components/Form/TextArea/code.mdx
@@ -167,7 +167,7 @@ Apply the classes `mc-textarea` on a standard `textarea` html tag:
   Use a minimum of 3 rows
 </HintItem>
 <HintItem>
-  Provide minlength and/or maxlength attributes if a text lenght is required from the user
+  Provide minlength and/or maxlength attributes if a text length is required from the user
 </HintItem>
 <HintItem dont>
   Never use the resize: none attribute for standards forms


### PR DESCRIPTION


## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes
Fixed typo.
```
lenght -> length
```