### PR TITLE
refactor(website/sitemapdata): remove unused keys in the SiteMapData query

### DIFF
--- a/packages/css-dev-tools/postcssPluginConfig.js
+++ b/packages/css-dev-tools/postcssPluginConfig.js
@@ -72,7 +72,7 @@ const productionPlugins = [
 ]
 
 if (CM.getKey('autoprefixer.disabled')) {
-  productionPlugins.splice(4,1);
+  productionPlugins.splice(4, 1)
 }
 
 if (CM.getKey('purgecss')) {

--- a/packages/gatsby-theme-styleguide/src/gatsby-components/SiteMapData/SiteMapData.js
+++ b/packages/gatsby-theme-styleguide/src/gatsby-components/SiteMapData/SiteMapData.js
@@ -37,12 +37,10 @@ const query = graphql`
             slug
             fileName {
               name
-              base
               relativePath
               extension
             }
           }
-          excerpt
         }
       }
     }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

When the `yarn develop` command is run after some time, the following code appears: 

```shell
warn This query took more than 15s to run — which is unusually long and might indicate you're querying too much or have some unoptimized code:
File path: /home/tii/clients/adeo/mozaic/mozaic-design-system/packages/gatsby-theme-styleguide/src/gatsby-components/SiteMapData/SiteMapData.js

Therefore, in order to reduce the execution time of this request, I removed the keys that are not used in the code of the styleguide theme
```
