### PR TITLE
build(npm-scripts/predevelop): remove the clean-cache command when running predevelop

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "build": "npx gatsby build",
     "develop": "npx gatsby develop",
     "format": "prettier --write '**/*.js'",
-    "predevelop": "yarn clean-cache && yarn tokens:clean-build",
+    "predevelop": "yarn tokens:clean-build",
     "release": "npx lerna version --conventional-commits --conventional-graduate --changelog-preset angular --message 'chore(release): publish %s' --create-release=github",
     "releaseBeta": "npx lerna version --conventional-commits --conventional-prerelease --changelog-preset angular --message 'chore(release): publish %s' --create-release=github --preid beta",
     "npm:publish": "npx lerna exec --bail=false npm publish",


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

When using the `yarn develop` command, Gatsby becomes increasingly slow.

This PR aims to remove the systematic deletion of the cache at the start of the develop phase. This is to see if we can take advantage of the cache generated by Gatsby to improve performance.
