### PR TITLE
refactor(component/accordion): change the way the trigger input is hidden

### DIFF
--- a/packages/styles/components/_c.accordion.scss
+++ b/packages/styles/components/_c.accordion.scss
@@ -65,8 +65,7 @@
   // this code with "input" as trigger is a backup code in order not to cause a breaking change
   // it should be removed once the teams have migrated to the new version of the component
   @at-root input#{$parent}__trigger {
-    opacity: 0;
-    position: absolute;
+    @include visually-hidden();
 
     &:checked {
       ~ #{$parent}__content {


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Change the way the trigger input is hidden.
Hide the trigger input with the `visually-hidden()` mixin and no longer with an absolute position