### PR TITLE
fix(component/loader): unify the loader text colour & the spinner colour

### DIFF
--- a/packages/styles/components/_c.loader.scss
+++ b/packages/styles/components/_c.loader.scss
@@ -22,10 +22,9 @@
 
   &__path {
     fill: none;
-    stroke-dashoffset: 0;
-    stroke-linecap: round;
     stroke-dasharray: 1, 200;
     stroke-dashoffset: 0;
+    stroke-linecap: round;
     animation: animate-dash-loader $animation-duration-loader ease-in-out
       infinite;
   }
@@ -33,7 +32,7 @@
   &__text {
     @include set-font-scale("05", "m");
 
-    color: $color-font-lightest;
+    color: currentColor;
   }
 
   @each $size, $props in $loader-sizes {

--- a/packages/styles/settings-tools/_s.loader.scss
+++ b/packages/styles/settings-tools/_s.loader.scss
@@ -15,13 +15,11 @@ $loader-sizes: (
     "width": $mu400,
   ),
 );
-
 $loader-theme: (
   "dark": $color-grey-900,
   "light": $color-grey-000,
   "primary": $color-primary-01-600,
 );
-
 $animation-duration-loader: 2s;
 $loader-default-size: map-get($loader-sizes, "m");
 $loader-default-theme: map-get($loader-theme, "primary");
@@ -44,7 +42,9 @@ $loader-default-theme: map-get($loader-theme, "primary");
 }
 
 @mixin set-loader-theme($color-loader, $parent) {
+  color: $color-loader;
+
   #{$parent}__path {
-    stroke: $color-loader;
+    stroke: currentColor;
   }
 }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [ ] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [ ] No

## Describe the changes

Unify the colour of the loader text with the colour of the spinner