### PR TITLE
fix(component/toggle): maintain the input position within the component

### DIFF
--- a/packages/styles/components/_c.toggle.scss
+++ b/packages/styles/components/_c.toggle.scss
@@ -3,10 +3,11 @@
   $parent: get-parent-selector(&);
 
   display: block;
+  position: relative;
 
   // hide the input
   &__input {
-    @include set-hidden-input();
+    @include visually-hidden();
   }
 
   &__content {
@@ -44,8 +45,7 @@
     &::before {
       background-color: $color-toggle-off-background;
       will-change: background-color, border-color, box-shadow;
-      transition:
-        background-color 100ms ease,
+      transition: background-color 100ms ease,
         border-color 100ms ease,
         box-shadow 200ms ease;
 
@@ -70,8 +70,7 @@
 
     // the switch pill foreground
     &::after {
-      background:
-        $color-toggle-off-circle
+      background: $color-toggle-off-circle
         url(inline-icons("control-cross-16", $color-toggle-off-background))
         no-repeat center;
       border: solid get-border("l") $color-toggle-off-background;
@@ -80,36 +79,33 @@
 
       :checked + & {
         border-color: $color-toggle-on-background;
-        background-image:
-          url(
-            inline-icons(
-              "notification-available-16",
-              $color-toggle-on-background
-            ));
+        background-image: url(
+          inline-icons(
+            "notification-available-16",
+            $color-toggle-on-background
+          ));
         transform: translate(100%, -50%);
       }
 
       :disabled + & {
         border-color: $color-toggle-disabled-background;
         background-color: $color-toggle-disabled-circle;
-        background-image:
-          url(
-            inline-icons(
-              "control-cross-16",
-              $color-toggle-disabled-background
-            ));
+        background-image: url(
+          inline-icons(
+            "control-cross-16",
+            $color-toggle-disabled-background
+          ));
         cursor: not-allowed;
       }
 
       :disabled:checked + & {
         border-color: $color-toggle-disabled-checked-background;
         background-color: $color-toggle-disabled-checked-circle;
-        background-image:
-          url(
-            inline-icons(
-              "notification-available-16",
-              $color-toggle-disabled-checked-background
-            ));
+        background-image: url(
+          inline-icons(
+            "notification-available-16",
+            $color-toggle-disabled-checked-background
+          ));
         cursor: not-allowed;
       }
     }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [ ] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [ ] No

## Describe the changes

**Maintain the input position within the component**

Details of the problem:

The input tag of the Toggle component is hidden using accessible hiding which has a `position: absolute` rule.
This behaviour causes a problem on Chrome when the layer contains this component.