### PR TITLE
feat(component/phonenumber): add additional styles

### DIFF
--- a/packages/styles/components/_c.phone-number.scss
+++ b/packages/styles/components/_c.phone-number.scss
@@ -10,12 +10,12 @@
   &__button {
     @include unstyle-button();
     @include set-select-size($select-default-size);
-    @include set-font-weight('semi-bold');
+    @include set-font-weight("semi-bold");
 
     display: flex;
     align-items: center;
     color: $color-grey-900;
-    border: get-border('s') solid $color-grey-600;
+    border: get-border("s") solid $color-grey-600;
     border-radius: $mu025 0 0 $mu025;
     border-right: none;
     padding-left: $mu100;
@@ -34,7 +34,7 @@
 
   &__list {
     @include unstyle-list();
-    @include set-box-shadow('l');
+    @include set-box-shadow("l");
 
     margin: 0;
     position: absolute;
@@ -66,13 +66,13 @@
   }
 
   &__item {
-    @include set-font-scale('05', 's');
+    @include set-font-scale("05", "s");
 
     display: flex;
     align-items: center;
     min-height: $mu300;
     padding-left: $mu075;
-    border-bottom: get-border('s') solid $color-grey-300;
+    border-bottom: get-border("s") solid $color-grey-300;
 
     &--focused {
       background: $color-grey-100;
@@ -82,6 +82,22 @@
   &__input {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
+  }
+
+  &__indicator,
+  &__country {
+    padding-left: $mu100;
+  }
+
+  &__overlay {
+    background: transparent;
+    inset: 0;
+    position: fixed;
+    z-index: 10;
+  }
+
+  &__dropdown {
+    z-index: 20;
   }
 
   &--focused {


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

In the **PhoneNumberInput** implementations on **Vue.js** & **Webcomponents**, CSS code is hardcoded in the styles part of the concerned files.

So I took this code to insert it in the `@mozaic-ds/styles package`, in order to have a "cleaner" management of this component.