### PR TITLE
feat(component/overlay): delete the `.mc-layer-overlay` & `.mc-modal-overlay` classes in favor of `.mc-overlay`

### DIFF
--- a/packages/styles/components/_c.layer.scss
+++ b/packages/styles/components/_c.layer.scss
@@ -241,8 +241,4 @@
   &-open {
     overflow: hidden;
   }
-
-  &-overlay {
-    @include set-page-overlay();
-  }
 }

--- a/src/docs/Components/Layers/code.mdx
+++ b/src/docs/Components/Layers/code.mdx
@@ -14,6 +14,7 @@ Import the **settings**, the **layer**, and the **button** scss files.
 
 @import 'components/_c.layer';
 @import 'components/_c.button';
+@import 'components/c.overlay';
 ```
 
 ## Usage
@@ -167,7 +168,7 @@ To do this, you can add the `mc-layer--ltr` to the `.mc-layer`.
 During the opening of a layer by Javascript, several events occur:
 
 - Added the `is-open` class on the `mc-layer__dialog` element.
-- An `mc-layer-overlay` element is generated in the DOM. This element must also have the class `is-visible`.
+- An `mc-overlay` element is generated in the DOM. This element must also have the class `is-visible`.
 
 #### Prevent body from scrolling
 

--- a/src/docs/Components/Layers/previews/border-scroll-bar.preview.html
+++ b/src/docs/Components/Layers/previews/border-scroll-bar.preview.html
@@ -76,5 +76,5 @@
       </div>
     </div>
   </div>
-  <div class="mc-layer-overlay is-visible" tabindex="-1" role="dialog"></div>
+  <div class="mc-overlay is-visible" tabindex="-1" role="dialog"></div>
 </div>

--- a/src/docs/Components/Layers/previews/border-scroll-bar.preview.scss
+++ b/src/docs/Components/Layers/previews/border-scroll-bar.preview.scss
@@ -5,6 +5,7 @@ html {
 }
 @import "components/c.layer";
 @import "components/c.button";
+@import "components/c.overlay";
 
 .example {
   background-color: #f6f7f7;

--- a/src/docs/Components/Layers/previews/cta-link.preview.html
+++ b/src/docs/Components/Layers/previews/cta-link.preview.html
@@ -27,5 +27,5 @@
       </div>
     </div>
   </div>
-  <div class="mc-layer-overlay is-visible" tabindex="-1" role="dialog"></div>
+  <div class="mc-overlay is-visible" tabindex="-1" role="dialog"></div>
 </div>

--- a/src/docs/Components/Layers/previews/cta-link.preview.scss
+++ b/src/docs/Components/Layers/previews/cta-link.preview.scss
@@ -5,6 +5,7 @@ html {
 }
 @import "components/c.layer";
 @import "components/c.button";
+@import "components/c.overlay";
 @import "components/c.links";
 
 $background-color-content: #eeeef0;

--- a/src/docs/Components/Layers/previews/cta-two.preview.html
+++ b/src/docs/Components/Layers/previews/cta-two.preview.html
@@ -29,5 +29,5 @@
       </div>
     </div>
   </div>
-  <div class="mc-layer-overlay is-visible" tabindex="-1" role="dialog"></div>
+  <div class="mc-overlay is-visible" tabindex="-1" role="dialog"></div>
 </div>

--- a/src/docs/Components/Layers/previews/cta-two.preview.scss
+++ b/src/docs/Components/Layers/previews/cta-two.preview.scss
@@ -5,6 +5,7 @@ html {
 }
 @import "components/c.layer";
 @import "components/c.button";
+@import "components/c.overlay";
 
 $background-color-content: #eeeef0;
 

--- a/src/docs/Components/Layers/previews/default.preview.html
+++ b/src/docs/Components/Layers/previews/default.preview.html
@@ -26,5 +26,5 @@
       </div>
     </div>
   </div>
-  <div class="mc-layer-overlay is-visible" tabindex="-1" role="dialog"></div>
+  <div class="mc-overlay is-visible" tabindex="-1" role="dialog"></div>
 </div>

--- a/src/docs/Components/Layers/previews/extended.preview.html
+++ b/src/docs/Components/Layers/previews/extended.preview.html
@@ -7,7 +7,10 @@
     aria-hidden="true"
     tabindex="-1"
   >
-    <div class="mc-layer__dialog mc-layer__dialog--extend is-open" role="document">
+    <div
+      class="mc-layer__dialog mc-layer__dialog--extend is-open"
+      role="document"
+    >
       <div class="mc-layer__header">
         <h2 class="mc-layer__title" id="layerTitle">Layer Title</h2>
         <button class="mc-layer__close" type="button">
@@ -26,6 +29,5 @@
       </div>
     </div>
   </div>
-  <div class="mc-layer-overlay is-visible" tabindex="-1" role="dialog"></div>
-  
+  <div class="mc-overlay is-visible" tabindex="-1" role="dialog"></div>
 </div>

--- a/src/docs/Components/Layers/previews/header-with-icon.preview.html
+++ b/src/docs/Components/Layers/previews/header-with-icon.preview.html
@@ -32,7 +32,7 @@
       </div>
     </div>
   </div>
-  <div class="mc-layer-overlay is-visible" tabindex="-1" role="dialog"></div>
+  <div class="mc-overlay is-visible" tabindex="-1" role="dialog"></div>
 </div>
 
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none">

--- a/src/docs/Components/Layers/previews/open-ltr.preview.html
+++ b/src/docs/Components/Layers/previews/open-ltr.preview.html
@@ -26,5 +26,5 @@
       </div>
     </div>
   </div>
-  <div class="mc-layer-overlay is-visible" tabindex="-1" role="dialog"></div>
+  <div class="mc-overlay is-visible" tabindex="-1" role="dialog"></div>
 </div>

--- a/src/docs/Components/Layers/previews/scrolling-content.preview.html
+++ b/src/docs/Components/Layers/previews/scrolling-content.preview.html
@@ -76,5 +76,5 @@
       </div>
     </div>
   </div>
-  <div class="mc-layer-overlay is-visible" tabindex="-1" role="dialog"></div>
+  <div class="mc-overlay is-visible" tabindex="-1" role="dialog"></div>
 </div>

--- a/src/docs/Components/Layers/previews/scrolling-content.preview.scss
+++ b/src/docs/Components/Layers/previews/scrolling-content.preview.scss
@@ -5,6 +5,7 @@ html {
 }
 @import "components/c.layer";
 @import "components/c.button";
+@import "components/c.overlay";
 
 .example {
   background-color: #f6f7f7;

--- a/src/docs/Components/Layers/previews/without-footer.preview.html
+++ b/src/docs/Components/Layers/previews/without-footer.preview.html
@@ -21,5 +21,5 @@
       </div>
     </div>
   </div>
-  <div class="mc-layer-overlay is-visible" tabindex="-1" role="dialog"></div>
+  <div class="mc-overlay is-visible" tabindex="-1" role="dialog"></div>
 </div>

--- a/src/docs/Components/Modals/code.mdx
+++ b/src/docs/Components/Modals/code.mdx
@@ -15,6 +15,7 @@ Import the **settings**, the **modal**, the **bodys**, and the **button** scss f
 @import 'components/c.divider';
 @import 'components/c.modal';
 @import 'components/c.button';
+@import 'components/c.overlay';
 ```
 
 ## Usage
@@ -156,7 +157,7 @@ Just as the width of a modal varies according to the rules indicated above, the 
 During the opening of a modal by Javascript, several events occur:
 
 - Added the `is-open` class on the `mc-modal__dialog` element.
-- A `mc-modal-overlay` element is generated in the DOM. This element must also have the class `is-visible`.
+- A `mc-overlay` element is generated in the DOM. This element must also have the class `is-visible`.
 
 <Preview path="opening" />
 

--- a/src/docs/Components/Modals/previews/opening.preview.html
+++ b/src/docs/Components/Modals/previews/opening.preview.html
@@ -28,5 +28,5 @@
       </footer>
     </div>
   </div>
-  <div class="mc-modal-overlay is-visible" tabindex="-1" role="dialog"></div>
+  <div class="mc-overlay is-visible" tabindex="-1" role="dialog"></div>
 </div>

--- a/src/docs/Components/Modals/previews/opening.preview.scss
+++ b/src/docs/Components/Modals/previews/opening.preview.scss
@@ -6,6 +6,7 @@ html {
 @import "typography/t.bodys";
 @import "components/c.modal";
 @import "components/c.button";
+@import "components/c.overlay";
 
 .example {
   background-color: #f6f7f7;


### PR DESCRIPTION
Resolves #1059

## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Delete the `.mc-layer-overlay` & `.mc-modal-overlay` classes in favor of `.mc-overlay`

GitHub issue number or Jira issue URL: https://github.com/adeo/mozaic-design-system/issues/1059
