### PR TITLE
fix(component/option-card): manage the use of the @at-root selector differently

### DIFF
--- a/packages/styles/components/_c.option-card.scss
+++ b/packages/styles/components/_c.option-card.scss
@@ -7,54 +7,52 @@
   cursor: pointer;
   position: relative;
 
-  &__input {
-    @at-root input#{&} {
+  @at-root input#{$parent}__input {
+    border-color: $color-input-border;
+    position: absolute;
+    right: $mu100;
+    top: $mu100;
+
+    &,
+    &:focus {
+      box-shadow: none;
+    }
+
+    &:checked {
+      border-color: $color-input-checked-border;
+    }
+
+    &:hover {
       border-color: $color-input-border;
-      position: absolute;
-      right: $mu100;
-      top: $mu100;
+    }
 
-      &,
-      &:focus {
-        box-shadow: none;
-      }
+    &:checked:hover {
+      border-color: $color-input-checked-border;
+    }
 
-      &:checked {
-        border-color: $color-input-checked-border;
-      }
+    &:hover + #{$parent}__label {
+      box-shadow: 0 0 0 2px $color-option-card-hover-label-shadow;
+    }
 
-      &:hover {
-        border-color: $color-input-border;
-      }
+    &:checked + #{$parent}__label {
+      border-color: $color-option-card-checked-label-border;
+      box-shadow: 0 0 0 $mu025 $color-option-card-checked-label-shadow;
+    }
 
-      &:checked:hover {
-        border-color: $color-input-checked-border;
-      }
+    &:focus + #{$parent}__label {
+      @include set-focus-floating();
+    }
 
-      &:hover + #{$parent}__label {
-        box-shadow: 0 0 0 2px $color-option-card-hover-label-shadow;
-      }
-
-      &:checked + #{$parent}__label {
-        border-color: $color-option-card-checked-label-border;
-        box-shadow: 0 0 0 $mu025 $color-option-card-checked-label-shadow;
-      }
-
-      &:focus + #{$parent}__label {
-        @include set-focus-floating();
-      }
-
-      &:checked ~ #{$parent}__content {
-        label,
-        button,
-        [href],
-        input,
-        select,
-        textarea,
-        #{$parent}__focusable,
-        [tabindex]:not([tabindex="-1"]) {
-          z-index: 2;
-        }
+    &:checked ~ #{$parent}__content {
+      label,
+      button,
+      [href],
+      input,
+      select,
+      textarea,
+      #{$parent}__focusable,
+      [tabindex]:not([tabindex="-1"]) {
+        z-index: 2;
       }
     }
   }

--- a/packages/styles/components/_c.option-card.scss
+++ b/packages/styles/components/_c.option-card.scss
@@ -7,52 +7,54 @@
   cursor: pointer;
   position: relative;
 
-  @at-root input#{$parent}__input {
-    border-color: $color-input-border;
-    position: absolute;
-    right: $mu100;
-    top: $mu100;
-
-    &,
-    &:focus {
-      box-shadow: none;
-    }
-
-    &:checked {
-      border-color: $color-input-checked-border;
-    }
-
-    &:hover {
+  &__input {
+    @include unify-parent("input") {
       border-color: $color-input-border;
-    }
+      position: absolute;
+      right: $mu100;
+      top: $mu100;
 
-    &:checked:hover {
-      border-color: $color-input-checked-border;
-    }
+      &,
+      &:focus {
+        box-shadow: none;
+      }
 
-    &:hover + #{$parent}__label {
-      box-shadow: 0 0 0 2px $color-option-card-hover-label-shadow;
-    }
+      &:checked {
+        border-color: $color-input-checked-border;
+      }
 
-    &:checked + #{$parent}__label {
-      border-color: $color-option-card-checked-label-border;
-      box-shadow: 0 0 0 $mu025 $color-option-card-checked-label-shadow;
-    }
+      &:hover {
+        border-color: $color-input-border;
+      }
 
-    &:focus + #{$parent}__label {
-      @include set-focus-floating();
-    }
+      &:checked:hover {
+        border-color: $color-input-checked-border;
+      }
 
-    &:checked ~ #{$parent}__content {
-      label,
-      button,
-      [href],
-      input,
-      select,
-      textarea,
-      #{$parent}__focusable,
-      [tabindex]:not([tabindex="-1"]) {
-        z-index: 2;
+      &:hover + #{$parent}__label {
+        box-shadow: 0 0 0 2px $color-option-card-hover-label-shadow;
+      }
+
+      &:checked + #{$parent}__label {
+        border-color: $color-option-card-checked-label-border;
+        box-shadow: 0 0 0 $mu025 $color-option-card-checked-label-shadow;
+      }
+
+      &:focus + #{$parent}__label {
+        @include set-focus-floating();
+      }
+
+      &:checked ~ #{$parent}__content {
+        label,
+        button,
+        [href],
+        input,
+        select,
+        textarea,
+        #{$parent}__focusable,
+        [tabindex]:not([tabindex="-1"]) {
+          z-index: 2;
+        }
       }
     }
   }

--- a/packages/styles/settings-tools/_t.selectors.scss
+++ b/packages/styles/settings-tools/_t.selectors.scss
@@ -1,15 +1,21 @@
-@function get-parent-selector($selector, $prefix: '.mc-') {
+@use "sass:selector";
+
+@function get-parent-selector($selector, $prefix: ".mc-") {
   $start-index: str-index(#{$selector}, $prefix);
 
   @if $start-index {
     $mozaic-class: str-slice(#{$selector}, $start-index);
 
     @return $mozaic-class;
-  }
-
-  @else {
+  } @else {
     @warn "Unknown prefix #{$prefix} in #{$selector} selector.";
 
     @return $selector;
+  }
+}
+
+@mixin unify-parent($child) {
+  @at-root #{selector.unify(&, $child)} {
+    @content;
   }
 }


### PR DESCRIPTION
Fix #1191

## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

<!-- Please describe the current behavior that you are modifying or a link to a relevant issue. -->

GitHub issue number or Jira issue URL: N/A

## Other information
