### PR TITLE
fix(layouts/grid): improve `.ml-flexy__col` selector scopable behaviour

### DIFF
--- a/packages/styles/layouts/_l.flexy.scss
+++ b/packages/styles/layouts/_l.flexy.scss
@@ -68,8 +68,10 @@
   // by default a gl-flexy__col is
   &__col {
     flex: 1 1 0;
+  }
 
-    .ml-flexy--gutter > #{$parent}__col {
+  &--gutter {
+    & > #{$parent}__col {
       @include set-flexy-col-gutter($size-gutter-screen-s);
 
       @include set-from-screen("m") {


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Improve `.ml-flexy__col` selector scopable behaviour