### PR TITLE
fix(component/phninput): remove `z-index` on `.mc-phone-number__dropdown` element

### DIFF
--- a/packages/styles/components/_c.phone-number.scss
+++ b/packages/styles/components/_c.phone-number.scss
@@ -97,10 +97,6 @@
     z-index: 10;
   }
 
-  &__dropdown {
-    z-index: 20;
-  }
-
   &--focused {
     #{$parent}__button {
       border-color: $color-info-500;


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Remove `z-index` on `.mc-phone-number__dropdown` element

GitHub issue number or Jira issue URL: https://github.com/adeo/mozaic-web-components/issues/439
