### PR TITLE
fix(components/modal/layer): improve overlay for scoped modules

### DIFF
--- a/packages/styles/components/_c.layer.scss
+++ b/packages/styles/components/_c.layer.scss
@@ -235,15 +235,16 @@
     overflow: hidden;
   }
 
-  &-overlay {
-    @include set-page-overlay();
-  }
-
   /* States */
   #{$parent}__dialog.is-open {
     pointer-events: all;
     transform: translate3d(0, 0, 0);
     transition: visibility 0s linear 0s, transform 0.4s;
     visibility: visible;
+  }
+
+  // Overlay
+  @at-root #{$parent}-overlay {
+    @include set-page-overlay();
   }
 }

--- a/packages/styles/components/_c.modal.scss
+++ b/packages/styles/components/_c.modal.scss
@@ -214,7 +214,8 @@
     }
   }
 
-  &-overlay {
+  // Overlay
+  @at-root #{$parent}-overlay {
     @include set-page-overlay();
   }
 }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

**Improve overlay for scoped modules**

When the Layer or Modal stylesheet is called in a scoped module, the overlay must not be wrapped in the module selector.