### PR TITLE
fix(components/tabs): add the modifier `no-padding`

### DIFF
--- a/packages/styles/components/_c.breadcrumb.scss
+++ b/packages/styles/components/_c.breadcrumb.scss
@@ -143,4 +143,8 @@
       }
     }
   }
+
+  &--no-padding {
+    padding-left: 0;
+  }
 }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [ ] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [ ] No

## Describe the changes

Add the modifier `no-padding`.

The removal of padding from the Breadcrumb component [has been done as part of the next major version](https://github.com/adeo/mozaic-design-system/pull/1098) of Mozaic.

However, some teams at LMFR have the need to use a Breadcrumb without padding in advance.

This is the reason for adding this new modifier.

GitHub issue number or Jira issue URL: https://github.com/adeo/mozaic-design-system/issues/1224
