### PR TITLE
fix(components/autocomplete-dropdown): adjust the padding-right value according to the clear button

### DIFF
--- a/packages/styles/components/_c.autocomplete.scss
+++ b/packages/styles/components/_c.autocomplete.scss
@@ -58,13 +58,21 @@
     z-index: $autocomplete-loader-zindex;
   }
 
+  &__trigger {
+    overflow: hidden;
+    padding-right: $mu300 - $mu025; // =44px
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &.is-invalid {
+      padding-right: ($mu200 + $mu025) * 2; // =72px
+    }
+  }
+
   &--multi {
     #{$parent} {
       &__trigger {
-        overflow: hidden;
         padding-left: calc(2.9375rem + var(--autocomplete-tag-width, 0px));
-        text-overflow: ellipsis;
-        white-space: nowrap;
       }
     }
   }

--- a/packages/styles/components/_c.dropdown.scss
+++ b/packages/styles/components/_c.dropdown.scss
@@ -52,17 +52,25 @@
 
     // invalid state
     .is-invalid + & {
-      right: 4.5rem; // =72px
+      right: ($mu200 + $mu025) * 2; // =72px
+    }
+  }
+
+  &__trigger {
+    overflow: hidden;
+    padding-right: ($mu200 + $mu025) * 2; // =72px
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &.is-invalid {
+      padding-right: $mu700 - $mu050; // =104px
     }
   }
 
   &--multi {
     #{$parent} {
       &__trigger {
-        overflow: hidden;
         padding-left: calc($mu075 + var(--dropdown-tag-width, 0px));
-        text-overflow: ellipsis;
-        white-space: nowrap;
       }
     }
   }

--- a/src/docs/Components/Form/Autocomplete/code.mdx
+++ b/src/docs/Components/Form/Autocomplete/code.mdx
@@ -157,6 +157,7 @@ To disable the **Autocomplete** component you have to add the `disabled` attribu
 
 <Highlight theme="warning">
 
-The autocomplete navigation has to be done using javascript.
+- The autocomplete navigation has to be done using javascript.
+- The clear button appears only when the users start to type or pick a value.
 
 </Highlight>

--- a/src/docs/Components/Form/Autocomplete/previews/default.preview.html
+++ b/src/docs/Components/Form/Autocomplete/previews/default.preview.html
@@ -22,7 +22,6 @@
         <svg class="mc-autocomplete__clear-icon">
           <use xlink:href="#ControlTagCross24" />
         </svg>
-
         <span class="mc-autocomplete__clear-text">Clear</span>
       </button>
     </div>

--- a/src/docs/Components/Form/Autocomplete/previews/disabled.preview.html
+++ b/src/docs/Components/Form/Autocomplete/previews/disabled.preview.html
@@ -17,6 +17,14 @@
           aria-expanded="false"
         />
       </div>
+
+      <!-- Clear Button -->
+      <button class="mc-autocomplete__clear" type="button">
+        <svg class="mc-autocomplete__clear-icon">
+          <use xlink:href="#ControlTagCross24" />
+        </svg>
+        <span class="mc-autocomplete__clear-text">Clear</span>
+      </button>
     </div>
 
     <!-- Listbox -->
@@ -101,6 +109,11 @@
   <symbol id="DisplaySearch24" viewBox="0 0 24 24">
     <path
       d="M18 6.05a7 7 0 00-10.51 9.14l-3.08 3.08a1 1 0 001.41 1.42l3.09-3.09A7 7 0 0018 6.05zm-1.41 8.49a5 5 0 110-7.08 5 5 0 01.04 7.08z"
+    />
+  </symbol>
+  <symbol id="ControlTagCross24" viewBox="0 0 24 24">
+    <path
+      d="M12 2a10 10 0 1010 10A10 10 0 0012 2zm4.14 12.7a1 1 0 01-1.41 1.42l-2.68-2.68-2.78 2.77a1 1 0 11-1.41-1.42L10.63 12 7.79 9.21a1 1 0 111.42-1.42l2.84 2.83 2.74-2.74a1 1 0 111.42 1.42L13.46 12z"
     />
   </symbol>
 </svg>

--- a/src/docs/Components/Form/Autocomplete/previews/disabled.preview.html
+++ b/src/docs/Components/Form/Autocomplete/previews/disabled.preview.html
@@ -17,14 +17,6 @@
           aria-expanded="false"
         />
       </div>
-
-      <!-- Clear Button -->
-      <button class="mc-autocomplete__clear" type="button">
-        <svg class="mc-autocomplete__clear-icon">
-          <use xlink:href="#ControlTagCross24" />
-        </svg>
-        <span class="mc-autocomplete__clear-text">Clear</span>
-      </button>
     </div>
 
     <!-- Listbox -->

--- a/src/docs/Components/Form/Autocomplete/previews/invalid.preview.html
+++ b/src/docs/Components/Form/Autocomplete/previews/invalid.preview.html
@@ -22,7 +22,6 @@
         <svg class="mc-autocomplete__clear-icon">
           <use xlink:href="#ControlTagCross24" />
         </svg>
-
         <span class="mc-autocomplete__clear-text">Clear</span>
       </button>
     </div>

--- a/src/docs/Components/Form/Autocomplete/previews/multi.preview.html
+++ b/src/docs/Components/Form/Autocomplete/previews/multi.preview.html
@@ -26,6 +26,7 @@
           autocomplete="off"
           aria-autocomplete="listbox"
           aria-expanded="false"
+          value="This is an autocomplete component in multi-selection version and with a long text value"
         />
       </div>
 
@@ -34,7 +35,6 @@
         <svg class="mc-autocomplete__clear-icon">
           <use xlink:href="#ControlTagCross24" />
         </svg>
-
         <span class="mc-autocomplete__clear-text">Clear</span>
       </button>
     </div>

--- a/src/docs/Components/Form/Dropdown/code.mdx
+++ b/src/docs/Components/Form/Dropdown/code.mdx
@@ -66,6 +66,7 @@ To disable the **Dropdown** component you have to add `disabled` attribut to the
 
 <Highlight theme="warning">
 
-The dropdown navigation has to be done using javascript.
+- The dropdown navigation has to be done using javascript.
+- The clear button appears only when the users start to type or pick a value.
 
 </Highlight>

--- a/src/docs/Components/Form/Dropdown/previews/default.preview.html
+++ b/src/docs/Components/Form/Dropdown/previews/default.preview.html
@@ -1,6 +1,7 @@
 <div class="example">
   <div class="mc-dropdown">
     <div class="mc-dropdown__main">
+      <!-- Trigger -->
       <button
         type="button"
         id="trigger"
@@ -17,7 +18,6 @@
         <svg class="mc-dropdown__clear-icon">
           <use xlink:href="#ControlTagCross24" />
         </svg>
-
         <span class="mc-dropdown__clear-text">Clear</span>
       </button>
     </div>

--- a/src/docs/Components/Form/Dropdown/previews/disabled.preview.html
+++ b/src/docs/Components/Form/Dropdown/previews/disabled.preview.html
@@ -13,14 +13,6 @@
       >
         Placeholder
       </button>
-
-      <!-- Clear Button -->
-      <button class="mc-dropdown__clear" type="button">
-        <svg class="mc-dropdown__clear-icon">
-          <use xlink:href="#ControlTagCross24" />
-        </svg>
-        <span class="mc-dropdown__clear-text">Clear</span>
-      </button>
     </div>
 
     <!-- Listbox -->

--- a/src/docs/Components/Form/Dropdown/previews/disabled.preview.html
+++ b/src/docs/Components/Form/Dropdown/previews/disabled.preview.html
@@ -1,6 +1,7 @@
 <div class="example">
   <div class="mc-dropdown">
     <div class="mc-dropdown__main">
+      <!-- Trigger -->
       <button
         type="button"
         id="trigger"
@@ -11,6 +12,14 @@
         disabled
       >
         Placeholder
+      </button>
+
+      <!-- Clear Button -->
+      <button class="mc-dropdown__clear" type="button">
+        <svg class="mc-dropdown__clear-icon">
+          <use xlink:href="#ControlTagCross24" />
+        </svg>
+        <span class="mc-dropdown__clear-text">Clear</span>
       </button>
     </div>
 

--- a/src/docs/Components/Form/Dropdown/previews/invalid.preview.html
+++ b/src/docs/Components/Form/Dropdown/previews/invalid.preview.html
@@ -1,6 +1,7 @@
 <div class="example">
   <div class="mc-dropdown">
     <div class="mc-dropdown__main">
+      <!-- Trigger -->
       <button
         type="button"
         id="trigger"
@@ -10,6 +11,14 @@
         aria-expanded="false"
       >
         Placeholder
+      </button>
+
+      <!-- Clear Button -->
+      <button class="mc-dropdown__clear" type="button">
+        <svg class="mc-dropdown__clear-icon">
+          <use xlink:href="#ControlTagCross24" />
+        </svg>
+        <span class="mc-dropdown__clear-text">Clear</span>
       </button>
     </div>
 
@@ -90,6 +99,14 @@
     </ul>
   </div>
 </div>
+
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none">
+  <symbol id="ControlTagCross24" viewBox="0 0 24 24">
+    <path
+      d="M12 2a10 10 0 1010 10A10 10 0 0012 2zm4.14 12.7a1 1 0 01-1.41 1.42l-2.68-2.68-2.78 2.77a1 1 0 11-1.41-1.42L10.63 12 7.79 9.21a1 1 0 111.42-1.42l2.84 2.83 2.74-2.74a1 1 0 111.42 1.42L13.46 12z"
+    />
+  </symbol>
+</svg>
 
 <!-- scripts -->
 <script>

--- a/src/docs/Components/Form/Dropdown/previews/multi.preview.html
+++ b/src/docs/Components/Form/Dropdown/previews/multi.preview.html
@@ -1,5 +1,8 @@
 <div class="example">
-  <div class="mc-dropdown mc-dropdown--multi" style="--dropdown-tag-width: 68px">
+  <div
+    class="mc-dropdown mc-dropdown--multi"
+    style="--dropdown-tag-width: 68px"
+  >
     <div class="mc-dropdown__main">
       <!-- Tag -->
       <span
@@ -21,6 +24,14 @@
         aria-expanded="false"
       >
         Placeholder
+      </button>
+
+      <!-- Clear Button -->
+      <button class="mc-dropdown__clear" type="button">
+        <svg class="mc-dropdown__clear-icon">
+          <use xlink:href="#ControlTagCross24" />
+        </svg>
+        <span class="mc-dropdown__clear-text">Clear</span>
       </button>
     </div>
 
@@ -117,6 +128,11 @@
   <symbol id="DisplaySearch24" viewBox="0 0 24 24">
     <path
       d="M18 6.05a7 7 0 00-10.51 9.14l-3.08 3.08a1 1 0 001.41 1.42l3.09-3.09A7 7 0 0018 6.05zm-1.41 8.49a5 5 0 110-7.08 5 5 0 01.04 7.08z"
+    />
+  </symbol>
+  <symbol id="ControlTagCross24" viewBox="0 0 24 24">
+    <path
+      d="M12 2a10 10 0 1010 10A10 10 0 0012 2zm4.14 12.7a1 1 0 01-1.41 1.42l-2.68-2.68-2.78 2.77a1 1 0 11-1.41-1.42L10.63 12 7.79 9.21a1 1 0 111.42-1.42l2.84 2.83 2.74-2.74a1 1 0 111.42 1.42L13.46 12z"
     />
   </symbol>
 </svg>


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

<!-- Please describe the current behavior that you are modifying or a link to a relevant issue. -->

Adjust the padding-right value according to the clear button