### PR TITLE
feat(component/autocomplete-dropdown): add the `clearable` modifier to manage the display of the clear button

### DIFF
--- a/packages/styles/components/_c.autocomplete.scss
+++ b/packages/styles/components/_c.autocomplete.scss
@@ -60,19 +60,27 @@
 
   &__trigger {
     overflow: hidden;
-    padding-right: $mu300 - $mu025; // =44px
+
     text-overflow: ellipsis;
     white-space: nowrap;
-
-    &.is-invalid {
-      padding-right: ($mu200 + $mu025) * 2; // =72px
-    }
   }
 
   &--multi {
     #{$parent} {
       &__trigger {
         padding-left: calc(2.9375rem + var(--autocomplete-tag-width, 0px));
+      }
+    }
+  }
+
+  &--clearable {
+    #{$parent} {
+      &__trigger {
+        padding-right: px-to-rem(44);
+
+        &.is-invalid {
+          padding-right: px-to-rem(72);
+        }
       }
     }
   }

--- a/packages/styles/components/_c.autocomplete.scss
+++ b/packages/styles/components/_c.autocomplete.scss
@@ -60,7 +60,6 @@
 
   &__trigger {
     overflow: hidden;
-
     text-overflow: ellipsis;
     white-space: nowrap;
   }

--- a/packages/styles/components/_c.dropdown.scss
+++ b/packages/styles/components/_c.dropdown.scss
@@ -52,25 +52,32 @@
 
     // invalid state
     .is-invalid + & {
-      right: ($mu200 + $mu025) * 2; // =72px
+      right: px-to-rem(72);
     }
   }
 
   &__trigger {
     overflow: hidden;
-    padding-right: ($mu200 + $mu025) * 2; // =72px
     text-overflow: ellipsis;
     white-space: nowrap;
-
-    &.is-invalid {
-      padding-right: $mu700 - $mu050; // =104px
-    }
   }
 
   &--multi {
     #{$parent} {
       &__trigger {
         padding-left: calc($mu075 + var(--dropdown-tag-width, 0px));
+      }
+    }
+  }
+
+  &--clearable {
+    #{$parent} {
+      &__trigger {
+        padding-right: px-to-rem(72);
+
+        &.is-invalid {
+          padding-right: px-to-rem(104);
+        }
       }
     }
   }

--- a/packages/styles/components/_c.dropdown.scss
+++ b/packages/styles/components/_c.dropdown.scss
@@ -9,7 +9,10 @@
 
   &__trigger {
     display: block;
+    overflow: hidden;
     text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     &.is-open {
       background-image: url(inline-icons("arrow-top-16", $color-grey-999));
@@ -54,12 +57,6 @@
     .is-invalid + & {
       right: px-to-rem(72);
     }
-  }
-
-  &__trigger {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   &--multi {

--- a/src/docs/Components/Form/Autocomplete/code.mdx
+++ b/src/docs/Components/Form/Autocomplete/code.mdx
@@ -131,13 +131,19 @@ Depending on your use cases, you have the possibility to use the **Autocomplete*
 
 The **Autocomplete** component in its **"mono-selection"** version allows you to select only one value at a time within the listbox.
 
-<Preview path="default" />
+<Preview path="default" nude />
 
 ### Autocomplte - multi-selection
 
 The **Autocomplete** component in its **"multi-selection"** version allows you to select several values within the listbox.
 
-<Preview path="multi" />
+<Preview path="multi" nude />
+
+<Highlight>
+
+When using the component with a clear button, you must add the class `mc-autocomplete--clearable` on the main `mc-autocomplete` element to ensure that the text field and the clear button are displayed correctly.
+
+</Highlight>
 
 ## States
 
@@ -145,13 +151,13 @@ The **Autocomplete** component in its **"multi-selection"** version allows you t
 
 To indicate that the **Autocomplete** component is in an invalid state, you have to add the `is-invalid` class to the `mc-autocomplete__trigger` element.
 
-<Preview path="invalid" />
+<Preview path="invalid" nude />
 
 ### Disabled
 
 To disable the **Autocomplete** component you have to add the `disabled` attribut to the `mc-autocomplete__trigger` element.
 
-<Preview path="disabled" />
+<Preview path="disabled" nude />
 
 ## Behaviour
 

--- a/src/docs/Components/Form/Autocomplete/previews/default.preview.html
+++ b/src/docs/Components/Form/Autocomplete/previews/default.preview.html
@@ -1,5 +1,5 @@
 <div class="example">
-  <div class="mc-autocomplete">
+  <div class="mc-autocomplete mc-autocomplete--clearable">
     <div class="mc-autocomplete__main">
       <!-- Input -->
       <div class="mc-left-icon-input">

--- a/src/docs/Components/Form/Autocomplete/previews/invalid.preview.html
+++ b/src/docs/Components/Form/Autocomplete/previews/invalid.preview.html
@@ -1,5 +1,5 @@
 <div class="example">
-  <div class="mc-autocomplete">
+  <div class="mc-autocomplete mc-autocomplete--clearable">
     <div class="mc-autocomplete__main">
       <!-- Input -->
       <div class="mc-left-icon-input is-invalid">

--- a/src/docs/Components/Form/Autocomplete/previews/multi.preview.html
+++ b/src/docs/Components/Form/Autocomplete/previews/multi.preview.html
@@ -1,5 +1,8 @@
 <div class="example">
-  <div id="js-autocomplete" class="mc-autocomplete mc-autocomplete--multi">
+  <div
+    id="js-autocomplete"
+    class="mc-autocomplete mc-autocomplete--clearable mc-autocomplete--multi"
+  >
     <div class="mc-autocomplete__main">
       <!-- Tag -->
       <span

--- a/src/docs/Components/Form/Dropdown/code.mdx
+++ b/src/docs/Components/Form/Dropdown/code.mdx
@@ -40,13 +40,19 @@ Depending on your use cases, you have the possibility to use the **Dropdown** co
 
 The **Dropdown** component in its **"mono-selection"** version allows you to select only one value at a time within the listbox.
 
-<Preview path="default" />
+<Preview path="default" nude />
 
 ### Dropdown - multi-selection
 
 The **Dropdown** component in its **"multi-selection"** version allows you to select several values within the listbox.
 
-<Preview path="multi" />
+<Preview path="multi" nude />
+
+<Highlight>
+
+When using the component with a clear button, you must add the class `mc-dropdown--clearable` on the main `mc-dropdown` element to ensure that the trigger button and the clear button are displayed correctly.
+
+</Highlight>
 
 ## States
 
@@ -54,13 +60,13 @@ The **Dropdown** component in its **"multi-selection"** version allows you to se
 
 To indicate that the **Dropdown** component is in an invalid state, you have to add the `is-invalid` class to the `mc-dropdown__trigger` element.
 
-<Preview path="invalid" />
+<Preview path="invalid" nude />
 
 ### Disabled
 
 To disable the **Dropdown** component you have to add `disabled` attribut to the `mc-dropdown__trigger` element.
 
-<Preview path="disabled" />
+<Preview path="disabled" nude />
 
 ## Behaviour
 

--- a/src/docs/Components/Form/Dropdown/previews/default.preview.html
+++ b/src/docs/Components/Form/Dropdown/previews/default.preview.html
@@ -1,5 +1,5 @@
 <div class="example">
-  <div class="mc-dropdown">
+  <div class="mc-dropdown mc-dropdown--clearable">
     <div class="mc-dropdown__main">
       <!-- Trigger -->
       <button

--- a/src/docs/Components/Form/Dropdown/previews/invalid.preview.html
+++ b/src/docs/Components/Form/Dropdown/previews/invalid.preview.html
@@ -1,5 +1,5 @@
 <div class="example">
-  <div class="mc-dropdown">
+  <div class="mc-dropdown mc-dropdown--clearable">
     <div class="mc-dropdown__main">
       <!-- Trigger -->
       <button

--- a/src/docs/Components/Form/Dropdown/previews/invalid.preview.scss
+++ b/src/docs/Components/Form/Dropdown/previews/invalid.preview.scss
@@ -8,6 +8,9 @@
 .example {
   @include set-font-family();
 
+  height: 250px;
   margin: $mu200 0;
   padding: 0 $mu200;
+  display: flex;
+  justify-content: center;
 }

--- a/src/docs/Components/Form/Dropdown/previews/multi.preview.html
+++ b/src/docs/Components/Form/Dropdown/previews/multi.preview.html
@@ -1,16 +1,18 @@
 <div class="example">
   <div
-    class="mc-dropdown mc-dropdown--multi"
+    class="mc-dropdown mc-dropdown--multi mc-dropdown--clearable"
     style="--dropdown-tag-width: 68px"
   >
     <div class="mc-dropdown__main">
       <!-- Tag -->
       <span
-        class="mc-dropdown__tag mc-tag-removable mc-tag-removable--dark mc-tag-removable--s"
+        id="js-tag"
+        class="mc-dropdown__tag mc-tag-removable mc-tag-removable--s mc-autocomplete__tag"
+        hidden
       >
-        <span class="mc-tag-removable__label"> 1 </span>
+        <span class="mc-tag-removable__label">1</span>
         <button class="mc-tag-removable__remove">
-          <span class="mc-tag-removable__remove-text"> Delete tag </span>
+          <span class="mc-tag-removable__remove-text">Delete tag</span>
         </button>
       </span>
 

--- a/src/docs/Components/Form/Dropdown/previews/multi.preview.scss
+++ b/src/docs/Components/Form/Dropdown/previews/multi.preview.scss
@@ -12,4 +12,6 @@
   height: 250px;
   margin: $mu200 0;
   padding: 0 $mu200;
+  display: flex;
+  justify-content: center;
 }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Add the `clearable` modifier to manage the display of the clear button
