### PR TITLE
fix(component/datatable): improve the overflow behaviour of the datatable

### DIFF
--- a/packages/styles/components/_c.datatable.scss
+++ b/packages/styles/components/_c.datatable.scss
@@ -26,13 +26,12 @@
   &__main {
     @include set-datatable-scrollbar();
 
-    overflow-x: auto;
-    overflow-y: hidden;
+    overflow: auto;
   }
 
   // table
   @include set-datatable-size($datatabke-default-celle-size);
-  
+
   &__table {
     @include set-datatable-base();
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Improve the overflow behaviour of the datatable

GitHub issue number or Jira issue URL: https://adeo-tech-community.slack.com/archives/CKQJZL7C4/p1672037763187509