### PR TITLE
refactor(component/modal): set a `min-height` value for the modal's header

### DIFF
--- a/packages/styles/components/_c.modal.scss
+++ b/packages/styles/components/_c.modal.scss
@@ -79,6 +79,7 @@
     display: flex;
     gap: $mu075;
     margin-bottom: $mu100;
+    min-height: px-to-rem(60);
     padding: $mu075 $mu075 $mu075 $mu100;
     position: relative;
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Set a `min-height` value for the modal's header
