### PR TITLE
fix(component/radio): correct the display of the disabled status

### DIFF
--- a/packages/styles/components/_c.radio.scss
+++ b/packages/styles/components/_c.radio.scss
@@ -95,10 +95,6 @@
       border-color: $color-input-disabled-background;
       cursor: not-allowed;
 
-      &::before {
-        background-color: $color-input-disabled-icon;
-      }
-
       &::-ms-check {
         background-color: $color-input-disabled-background;
         border-color: $color-input-disabled-background;
@@ -107,6 +103,13 @@
 
       & + #{$parent}__label {
         color: $color-input-disabled-label;
+      }
+
+      // disabled & checked
+      &:checked {
+        &::before {
+          background-color: $color-input-disabled-icon;
+        }
       }
     }
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [ ] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [ ] No

## Describe the changes

Correct the display of the disabled status
