### PR TITLE
chore(previews): avoid reloading all previews when scss changes

### DIFF
--- a/packages/gatsby-source-preview/gatsby-node.js
+++ b/packages/gatsby-source-preview/gatsby-node.js
@@ -111,10 +111,10 @@ exports.sourceNodes = (tools, configOptions) => {
     ) {
       reporter.info(`changed PREVIEW file at ${path}`)
 
-      // is global style? Just rebuild everything!
+      // Avoid reloading all previews during dev
       const globalStylePath = 'packages/styles/'
       if (path.replace(/\\/g, '/').indexOf(globalStylePath) > -1) {
-        return buildPreviews()
+        return buildPreviews(path)
           .then(reporter.success(`previews built`))
           .catch((err) => reporter.error(err))
       }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [ ] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [ ] No

## Describe the changes

<!-- Please describe the current behavior that you are modifying or a link to a relevant issue. -->

GitHub issue number or Jira issue URL: N/A

## Other information
