### PR TITLE
feat(styles/settings): make the `font-size` definition relative to the magic-unit value

### DIFF
--- a/packages/styles/settings-tools/_s.fonts-scale.scss
+++ b/packages/styles/settings-tools/_s.fonts-scale.scss
@@ -8,7 +8,7 @@
 }
 
 @mixin set-font-scale($size, $line-height: "l") {
-  font-size: get-token(size, font, $size);
+  font-size: get-token(size, font, $size) * $magic-unit;
 
   @include set-line-height($size, $line-height);
 }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

**Make the `font-size` definition relative to the magic-unit value**

Currently, when a user customizes the value of the variable `$local-rem-value`, the values of the paddings & margins, update well, because they are based on the **magic-unit**. 

However the font-size of the components defined with the mixin `set-font-scale()` it does not adapt.

So we should link the property value `font-size` to the value of the **magic-unit**, so that the font-size also adapts when the value of the variable `$local-rem-value` changes.