### PR TITLE
fix(component/stepper): remove default background of 'indicator' element

### DIFF
--- a/packages/styles/components/_c.stepper.scss
+++ b/packages/styles/components/_c.stepper.scss
@@ -109,7 +109,6 @@
     @include set-font-weight("semi-bold");
 
     align-items: center;
-    background-color: $color-stepper-indicator-background;
     border: get-border("m") solid $color-stepper-indicator-border;
     border-radius: 50%;
     box-sizing: border-box;


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Remove default background of 'indicator' element