### PR TITLE
fix(component/stars-input): stringify "background-image" parameter to avoid ";" expectation SASS error

### DIFF
--- a/packages/styles/components/_c.stars-input.scss
+++ b/packages/styles/components/_c.stars-input.scss
@@ -95,10 +95,10 @@
             @include set-stars-size($props);
 
             background-size: $bg-variation-size $bg-variation-size;
-            background-image: url(inline-icons($icon-full, $color-star-full));
+            background-image: url(inline-icons("#{$icon-full}", $color-star-full));
 
             &::before {
-              background-image: url(inline-icons($icon-full, $color-star-full));
+              background-image: url(inline-icons("#{$icon-full}", $color-star-full));
               background-size: $bg-variation-size $bg-variation-size;
             }
           }
@@ -109,14 +109,14 @@
               & ~ #{$parent}__label {
                 background-image: url(
                   inline-icons(
-                    $icon-empty,
+                    "#{$icon-empty}",
                     $color-star-full
                   ));
               }
               & + #{$parent}__label {
                 background-image: url(
                   inline-icons(
-                    $icon-full,
+                    "#{$icon-full}",
                     $color-star-full
                   ));
               }
@@ -126,7 +126,7 @@
               & ~ #{$parent}__label {
                 background-image: url(
                   inline-icons(
-                    $icon-empty,
+                    "#{$icon-empty}",
                     $color-star-full
                   ));
               }
@@ -134,7 +134,7 @@
               & + #{$parent}__label {
                 background-image: url(
                   inline-icons(
-                    $icon-full,
+                    "#{$icon-full}",
                     $color-star-full
                   ));
               }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

I have this following error when `c.stars-input` is imported: `[sass] expected ";".` on `background-image` CSS tag.

![image](https://user-images.githubusercontent.com/2929786/233607318-76f1b3df-6727-44fe-bc99-31ad5687313e.png)

I reproduced the error on this minimalist repo: https://github.com/pinguet62/mozaic-starsinput
ℹ️ You can find distinct commits.

## Other information

Apparently there is an [issue between `url()` and SASS variables](https://stackoverflow.com/questions/8608498/have-a-variable-in-images-path-in-sass) and a workaround is to use interpolation.
And wrap some SASS variable with `#{ }` seems fix the problem.
I don't know if it's the best solution 😉