### PR TITLE
fix(component/modal): manage long content by default

### DIFF
--- a/packages/styles/components/_c.modal.scss
+++ b/packages/styles/components/_c.modal.scss
@@ -3,6 +3,11 @@
 .mc-modal {
   $parent: get-parent-selector(&);
 
+  &,
+  * {
+    box-sizing: border-box;
+  }
+
   @include set-font-face();
   @include set-dialog-base();
 
@@ -26,6 +31,7 @@
     display: flex;
     flex-direction: column;
     opacity: 0;
+    max-height: 100%;
     position: relative;
     transform: translateY(-25%);
     transition: visibility 0s linear 0.4s, transform 0.4s ease,
@@ -133,6 +139,7 @@
 
     flex: 1 1;
     color: $color-font-darker;
+    display: flex;
     overflow: hidden;
     padding-left: math.div($mu100, 2);
     padding-right: math.div($mu100, 2);
@@ -144,6 +151,7 @@
   }
 
   &__content {
+    flex-grow: 1;
     max-height: 100%;
     overflow-y: auto;
     overflow-x: hidden;
@@ -210,18 +218,6 @@
 
   &-open {
     overflow: hidden;
-  }
-
-  &--overflow {
-    #{$parent} {
-      &__dialog {
-        height: 100%;
-      }
-
-      &__footer {
-        box-shadow: 0 $mu025 $mu125 0 mt-rgba($color-dialog-footer-shadow, 0.2);
-      }
-    }
   }
 
   // Overlay

--- a/src/docs/Components/Modals/code.mdx
+++ b/src/docs/Components/Modals/code.mdx
@@ -115,9 +115,6 @@ In cases where it is not necessary, you can use a modal without heading, as foll
 
 ### Scrolling long content
 
-In some cases, the content paragraph can be bigger than the modal's viewport. A dropped shadow on the top of the footer is used to indicate to the user that this is a scrollable content.
-Add the `mc-modal--overflow` modifier to the global wrapper (`mc-modal`).
-
 <Preview path="big-content" />
 
 ### Footer - two call to actions

--- a/src/docs/Components/Modals/previews/big-content.preview.html
+++ b/src/docs/Components/Modals/previews/big-content.preview.html
@@ -1,6 +1,6 @@
 <div class="example">
   <div
-    class="mc-modal mc-modal--overflow"
+    class="mc-modal"
     tabindex="-1"
     role="dialog"
     aria-labelledby="modalTitle"

--- a/src/docs/Components/Modals/previews/big-content.preview.scss
+++ b/src/docs/Components/Modals/previews/big-content.preview.scss
@@ -1,6 +1,5 @@
 @import "settings-tools/all-settings";
 @include import-font-families();
-@import "generic/g.reset";
 @import "typography/t.bodys";
 @import "components/c.modal";
 @import "components/c.button";


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

### Manage long content by default

This PR changes the Modal component code so that long content is managed by default without the need to add a modifier.
The code therefore makes the following changes:

- Delete the `mc-modal--overflow` modifier
- Removal of the shadow on the footer (to be ISO with Figma mock-ups)
- Inclusion of certain style evolutions made on the [Mozaic-React](https://github.com/adeo/mozaic-react/blob/master/src/components/Modal/Modal.scss) side

GitHub issue number or Jira issue URL: N/A

## Other information
