### PR TITLE
fix: label prevents clicking on the accordion

### DIFF
--- a/packages/styles/components/_c.accordion.scss
+++ b/packages/styles/components/_c.accordion.scss
@@ -29,6 +29,7 @@
     display: block;
     padding-left: $mu050;
     position: relative;
+    pointer-events: none;
 
     &:hover {
       background-color: $color-grey-100;


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [X] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [X] No

## Describe the changes

In Mozaic Vue, the accordion isn't opening when clicking on text due to the label tag.
I had a pointer-events: none on the label to fix this.

GitHub issue number or Jira issue URL: N/A

## Other information
