### PR TITLE
Revert "fix: label prevents clicking on the accordion (#1448)"

### DIFF
--- a/packages/styles/components/_c.accordion.scss
+++ b/packages/styles/components/_c.accordion.scss
@@ -29,7 +29,6 @@
     display: block;
     padding-left: $mu050;
     position: relative;
-    pointer-events: none;
 
     &:hover {
       background-color: $color-grey-100;


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

This reverts commit ffd367f0e00d4699420efa85cfd9249a78eb6d0b.

> We go back to the previous version because this evolution creates side effects in the libs that consume this evolution.

## Other information
