### PR TITLE
fix(component/optioncard): add `position:relative` on focusable elements

### DIFF
--- a/packages/styles/components/_c.option-card.scss
+++ b/packages/styles/components/_c.option-card.scss
@@ -46,6 +46,7 @@
         textarea,
         #{$parent}__focusable,
         [tabindex]:not([tabindex="-1"]) {
+          position: relative;
           z-index: 3;
         }
       }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Add `position:relative` on focusable elements

GitHub issue number or Jira issue URL: 

related to => https://github.com/adeo/mozaic-vue/issues/1489
