### PR TITLE
docs(datatable): fix mass selection behaviour

### DIFF
--- a/src/docs/Components/DataTable/index.mdx
+++ b/src/docs/Components/DataTable/index.mdx
@@ -121,7 +121,7 @@ Depending on the context, the column header can be fixed as well.
 
 #### Mass selection
 
-Once users select a row, a dedicated banner for mass selection will appear, allowing them to select all rows in the table, including all pages.
+Once users select all rows of a page, a dedicated banner for mass selection will appear, allowing them to select all rows in the table, including all pages.
 
 #### Empty state
 

--- a/src/docs/Components/DataTable/index.mdx
+++ b/src/docs/Components/DataTable/index.mdx
@@ -121,7 +121,7 @@ Depending on the context, the column header can be fixed as well.
 
 #### Mass selection
 
-Once users select all rows of a page, a dedicated banner for mass selection will appear, allowing them to select all rows in the table, including all pages.
+Once users have selected all the rows on a page, a dedicated banner for mass selection will appear, allowing them to select all rows in the table, including all pages.
 
 #### Empty state
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [X] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [X] No

## Describe the changes

<!-- Fix documentation mistake on mass selection behaviour on datatable. Banner appears when all rows are selected, not only one. -->

GitHub issue number or Jira issue URL: https://github.com/adeo/mozaic-web-components/issues/764

## Other information
Figma prototype: https://www.figma.com/proto/Fwvg2vuovdgIZZudFzwmLG/02.-Datatable-%F0%9F%94%B5?page-id=578%3A79523&type=design&node-id=3849-51504&viewport=193%2C-128%2C0.26&t=CbFkLJpaf5KhOoRb-1&scaling=min-zoom&starting-point-node-id=3849%3A51504&mode=design