### PR TITLE
fix(component/datatable): remove unnecessary paddings from datatable header elements

### DIFF
--- a/packages/styles/components/_c.datatable-header.scss
+++ b/packages/styles/components/_c.datatable-header.scss
@@ -3,14 +3,14 @@
 .mc-datatable {
   $parent: get-parent-selector(&);
 
+  &__topbar,
+  &__filters {
+    padding-bottom: $mu100;
+  }
+
   // Header - Topbar
   &__topbar {
     justify-content: space-between;
-
-    padding: {
-      top: $mu100;
-      bottom: $mu100;
-    }
 
     &,
     &-edition,
@@ -38,14 +38,14 @@
   // Header - Filters
   &__filters {
     align-items: center;
-    border-top: get-border(s) solid $color-datatable-filters-border;
     display: flex;
     flex-wrap: wrap;
     gap: $mu100;
     justify-content: flex-end;
-    padding: {
-      top: $mu100;
-      bottom: $mu100;
+
+    &:not(:only-child) {
+      border-top: get-border(s) solid $color-datatable-filters-border;
+      padding-top: $mu100;
     }
   }
 }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Remove unnecessary paddings from datatable header elements

## GitHub issue number or Jira issue URL

<!-- Please indicate a link or a number related to the issue or the Jira concerned. -->

## Other information

PR brought back from https://github.com/adeo/ads-styles/pull/20
