### PR TITLE
ci(gha/workflows): replace custom `SVC_GH_API_TOKEN` with standard `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      deployments: write
 
     steps:
       - name: Extract branch name
@@ -33,7 +34,7 @@ jobs:
       - name: Build a production website
         run: yarn build
         env:
-          GH_API_TOKEN: ${{ secrets.SVC_GH_API_TOKEN }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./ci/docker-wait
         env:
           GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
@@ -44,7 +45,7 @@ jobs:
         id: deployment
         with:
           step: start
-          token: ${{ secrets.SVC_GH_API_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           env: staging
           ref: ${{ github.head_ref }}
       - id: 'auth'
@@ -65,7 +66,7 @@ jobs:
         uses: bobheadxi/deployments@v1
         with:
           step: finish
-          token: ${{ secrets.SVC_GH_API_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Build a production website
         run: yarn build
         env:
-          GH_API_TOKEN: ${{ secrets.SVC_GH_API_TOKEN }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: deployment
         uses: bobheadxi/deployments@v1
         id: deployment
         with:
           step: start
-          token: ${{ secrets.SVC_GH_API_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           env: production
           ref: ${{ github.head_ref }}
       - id: 'auth'


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Replace custom `SVC_GH_API_TOKEN` with standard `GITHUB_TOKEN`

GitHub issue number or Jira issue URL: N/A

## Other information
