### PR TITLE
fix(Tooltip): make tooltip usable by keyboard for accessibility

### DIFF
--- a/packages/styles/components/_c.tooltip.scss
+++ b/packages/styles/components/_c.tooltip.scss
@@ -8,11 +8,16 @@
   position: relative;
 
   &:focus,
-  &:hover {
+  &:hover,
+  &:focus-within {
     cursor: help;
 
     #{$parent}__content {
       visibility: visible;
+    }
+
+    #{$parent}--hidden {
+      visibility: hidden;
     }
   }
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

To make the Tooltip component usable by keyboard, we need to display the tooltip when the component receives focus from keyboard navigation. Today, there is no possibility for keyboard-only users to focus and see the component.

Github issue number : #1545 

## Other information

The PR is linked with [this other PR](https://github.com/adeo/mozaic-react/pull/220), for mozaic react. The mozaic react PR doesn't work without this one.