### PR TITLE
fix(component/listbox): re-add styles relating to ListboxActions position

### DIFF
--- a/packages/styles/components/_c.listbox.scss
+++ b/packages/styles/components/_c.listbox.scss
@@ -181,6 +181,18 @@
   &--actions {
     min-width: px-to-rem(278);
 
+    &.align-top {
+      transform: translate(0, calc(-100% - #{$mu150}));
+    }
+
+    &.align-right {
+      transform: translate(calc(-100% + #{$mu150}), 0);
+
+      &.align-top {
+        transform: translate(calc(-100% + #{$mu150}), calc(-100% - #{$mu150}));
+      }
+    }
+
     #{$parent} {
       &__list {
         &:not(:last-child) {


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Re-add styles relating to ListboxActions position

## GitHub issue number or Jira issue URL:

Related to https://github.com/adeo/mozaic-vue/issues/1836

## Other information
