### PR TITLE
fix(component/breadcrumb): remove extra padding on 1st item

### DIFF
--- a/packages/styles/components/_c.breadcrumb.scss
+++ b/packages/styles/components/_c.breadcrumb.scss
@@ -62,28 +62,22 @@
       flex-shrink: 0;
     }
 
-    &.is-active,
-    &:only-child,
     &:not(:first-child) {
+      background-image: url(inline-icons(
+        "arrow-right-16",
+        $color-breadcrumb-arrow
+      ));
       padding-left: $mu150;
-    }
-
-    &:not(:first-child) {
-      background-image: url(
-        inline-icons(
-          "arrow-right-16",
-          $color-breadcrumb-arrow
-        ));
     }
 
     &.is-active,
     &:only-child {
       @media screen and (max-width: ($screen-l - 1)) {
-        background-image: url(
-          inline-icons(
-            "arrow-left-16",
-            $color-breadcrumb-arrow
-          ));
+        background-image: url(inline-icons(
+          "arrow-left-16",
+          $color-breadcrumb-arrow
+        ));
+        padding-left: $mu150;
       }
     }
   }
@@ -111,21 +105,19 @@
     #{$parent} {
       &__item {
         &:not(:first-child) {
-          background-image: url(
-            inline-icons(
-              "arrow-right-16",
-              $color-breadcrumb-arrow-invert
-            ));
+          background-image: url(inline-icons(
+            "arrow-right-16",
+            $color-breadcrumb-arrow-invert
+          ));
         }
 
         &.is-active,
         &:only-child {
           @media screen and (max-width: ($screen-l - 1)) {
-            background-image: url(
-              inline-icons(
-                "arrow-left-16",
-                $color-breadcrumb-arrow-invert
-              ));
+            background-image: url(inline-icons(
+              "arrow-left-16",
+              $color-breadcrumb-arrow-invert
+            ));
           }
         }
       }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Remove extra padding on 1st only-child item on desktop viewport.

## GitHub issue number or Jira issue URL:

Related https://github.com/adeo/mozaic-vue/issues/1821

## Other information
