### PR TITLE
fix(component/tooltip): update word-break to avoid cutting word in half

### DIFF
--- a/packages/styles/components/_c.tooltip.scss
+++ b/packages/styles/components/_c.tooltip.scss
@@ -35,7 +35,7 @@
     white-space: normal;
     z-index: 1000;
     border: get-border("s") solid $color-tooltip-border;
-    word-break: break-all;
+    word-break: break-word;
 
     // MS Issue : IE10, IE11 don't support intrinsic widths
     @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [ ] Yes
- [x] No (not available)

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Word breaks in tooltips where cutting words for no reason.
`word-break: break-word` is deprecated so maybe we should use
`overflow-wrap: break-word` instead
I don't know if it was on purpose to force cutting words in tooltips but it cause some UX/UI issues in our team

GitHub issue number or Jira issue URL: N/A

## Other information

Example:
![image](https://github.com/adeo/mozaic-design-system/assets/77327349/00d319e7-6879-4a22-950b-d4ef2fd739fd)
