### PR TITLE
fix(component/textarea): limit resize beyond the max width

### DIFF
--- a/packages/styles/components/_c.textarea.scss
+++ b/packages/styles/components/_c.textarea.scss
@@ -13,6 +13,7 @@
   border: $border-width solid $color-input-border;
   background: $color-input-background;
   transition: all ease 200ms;
+  max-width: 100%;
   // remove border height and center baseline optically
   padding:
     calc(#{$mu075} - 0.125em - #{$border-width}) $mu075


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Limit resize beyond the max width

## GitHub issue number or Jira issue URL:

Fix #1469

## Other information
