### PR TITLE
feat(components/datatable): update empty states display

### DIFF
--- a/packages/styles/components/_c.datatable-empty.scss
+++ b/packages/styles/components/_c.datatable-empty.scss
@@ -1,0 +1,25 @@
+.mc-datatable {
+  $parent: get-parent-selector(&);
+
+  &__empty {
+    @include set-font-scale("05", "m"); // 16px / 22px
+
+    align-items: center;
+    background-color: $color-datatable-empty-background;
+    color: $color-datatable-empty-color;
+    display: flex;
+    flex-direction: column;
+    gap: $mu100; // =16px
+    height: px-to-rem(291);
+    justify-content: center;
+    text-align: center;
+
+    p {
+      margin: 0 auto;
+    }
+
+    strong {
+      @include set-font-scale("06", "m"); // 18px / 24px
+    }
+  }
+}

--- a/packages/styles/components/_c.datatable.scss
+++ b/packages/styles/components/_c.datatable.scss
@@ -67,10 +67,6 @@
 
   tbody {
     tr {
-      &:hover:not(#{$parent}__empty) {
-        background-color: $color-datatable-cell-background-hover;
-      }
-
       &.selected {
         background-color: $color-datatable-cell-background-selected;
       }
@@ -148,34 +144,6 @@
     &-number {
       @at-root td#{&} {
         text-align: right;
-      }
-    }
-  }
-
-  // empty
-  &__empty {
-    &,
-    &:hover {
-      background-color: $color-datatable-empty-background;
-    }
-
-    &-cell {
-      color: $color-datatable-empty-color;
-    }
-
-    &-content {
-      @include set-font-scale("05", "m"); // 16px / 22px
-
-      align-items: center;
-      color: $color-datatable-empty-color;
-      display: flex;
-      gap: $mu150;
-      min-height: px-to-rem(310);
-      justify-content: center;
-      text-align: center;
-
-      strong {
-        @include set-font-scale("06", "m"); // 18px / 24px
       }
     }
   }
@@ -303,7 +271,7 @@
       }
     }
   }
-  
+
   &--overflow-visible {
     #{$parent} {
       &__container {


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a breaking change?

read [What is a breaking change ?](https://mozaic.adeo.cloud/contributing/developers/git-conventions/#breaking-changes-)

- [ ] Yes
- [x] No

## Have you written a story about your changes?

- [ ] Yes
- [x] No

## Describe the changes

Update the display of empty states to be fully consistent with Figma mockups

## GitHub issue number _(or Jira issue URL)_

<!-- Please indicate a link or a number related to the issue or the Jira concerned. -->

## Other information

**Figma mockups:**
https://www.figma.com/file/Fwvg2vuovdgIZZudFzwmLG/02.-Datatable-%F0%9F%94%B5?type=design&node-id=4889-92340&mode=design&t=YwzoTVTHAFHpQGhS-4
