### PR TITLE
feat(components/datatable): restrict the application of some styles to the root table

### DIFF
--- a/packages/styles/components/_c.datatable.scss
+++ b/packages/styles/components/_c.datatable.scss
@@ -175,7 +175,7 @@
 
       &__table {
         > tbody {
-          tr:last-child {
+          > tr:last-child {
             th,
             td {
               border-bottom: transparent;


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Restrict the application of some styles to the root table

## GitHub issue number or Jira issue URL: N/A

## Other information
