### PR TITLE
fix(components/stepper): compact variation - not take `skrinked` variation into account

### DIFF
--- a/packages/styles/components/_c.stepper.scss
+++ b/packages/styles/components/_c.stepper.scss
@@ -136,7 +136,7 @@
     color: $color-stepper-title;
   }
 
-  &:not(#{$parent}--compact):not(#{$parent}--shrinked) {
+  &:not(#{$parent}--compact) {
     #{$parent}__item {
       &:first-child::before,
       &:last-child::after {


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Compact variation - not take `skrinked` variation into account.

GitHub issue number or Jira issue URL: N/A

## Other information
