### PR TITLE
fix(listbox): set same style on hover and focus

### DIFF
--- a/packages/styles/components/_c.listbox.scss
+++ b/packages/styles/components/_c.listbox.scss
@@ -37,7 +37,7 @@
     padding-right: $mu075;
     position: relative;
 
-    &:not(#{$selector-empty}):not(.is-disabled):hover {
+    &:not(#{$selector-empty}):not(.is-disabled):hover, &:has(.mc-listbox__input:focus) {
       background-color: $color-listbox-tile-hover-background;
       box-shadow: inset 9px 0 0 -7px $color-listbox-tile-shadow;
     }


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

On the listbox, there was no visual clue when an element of the list has the focus. The change applies the same style on focus as on the hover.

## GitHub issue number or Jira issue URL: N/A

[1588](https://github.com/adeo/mozaic-design-system/issues/1588)
