### PR TITLE
fix(tools/tokens): custom source path should be relative to project root

### DIFF
--- a/packages/tokens/config.js
+++ b/packages/tokens/config.js
@@ -21,7 +21,7 @@ const getSourceDir = (preset, customSourcePath) => {
   source.push(getPath(sourceDir.lm))
 
   if (customSourcePath)
-    source.push(getPath(`${customSourcePath}${sourceDir['lm']}`))
+    source.push(`${customSourcePath}${sourceDir['lm']}`)
 
   if (preset) source.splice(1, 0, getPath(sourceDir[preset]))
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [X] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [X] No

## Describe the changes

We use Mozaic on the [Front-End Enablers portal](https://fee.adeo.cloud/) and we customized tokens to have our own primary colors.
Here is our mozaic.config.js :
```javascript
module.exports = {
  preset: 'adeo',
  tokens: {
    localTokensSrcPath: './src/styles/tokens/',
    localTokensExportPath: './dist/tokens/',
  },
  ...
};
```

It used to work for a while, but recently when we upgraded `@mozaic-ds/tokens` from `1.68.0` to `1.72.0`, and our custom tokens where not taken into consideration anymore.
After some investigations, it seems that now the `localTokensSrcPath` is relative to `node_modules/@mozaic-ds/tokens/` and not the root of the project as it used to be.
I updated our Mozaic configuration with the following and it works well:
```javascript
module.exports = {
  preset: 'adeo',
  tokens: {
    localTokensSrcPath: '../../../src/styles/tokens/',
    localTokensExportPath: './dist/tokens/',
  },
  ...
};
```

However I think it's a bug. In version `1.68.0` the custom source path was calculated this way:
```javascript
const source = localSrcPath
  ? [getPath('properties/**/*.json'), `${localSrcPath}properties/**/*.json`]
  : [getPath('properties/**/*.json')]
```
and now it's like this:
```javascript
 if (customSourcePath)
    source.push(getPath`${customSourcePath}${sourceDir['lm']}`))
```
The method `getPath` shouldn't be called when computing the custom source path.