### PR TITLE
feat(component/listbox): allow the `min-width` to be changed

### DIFF
--- a/packages/styles/components/_c.listbox.scss
+++ b/packages/styles/components/_c.listbox.scss
@@ -37,7 +37,8 @@
     padding-right: $mu075;
     position: relative;
 
-    &:not(#{$selector-empty}):not(.is-disabled):hover, &:has(.mc-listbox__input:focus) {
+    &:not(#{$selector-empty}):not(.is-disabled):hover,
+    &:has(.mc-listbox__input:focus) {
       background-color: $color-listbox-tile-hover-background;
       box-shadow: inset 9px 0 0 -7px $color-listbox-tile-shadow;
     }
@@ -122,7 +123,7 @@
 
   &--options {
     max-height: px-to-rem(221);
-    min-width: px-to-rem(288);
+    min-width: var(--listbox-minwidth, #{px-to-rem(288)});
 
     #{$parent} {
       &__flag,


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

### Allow the `min-width` to be changed

At present, the minimum width of the component is set at 288px in accordance with the Figma mock-ups.
However, some teams have expressed the wish to have a smaller width in certain cases.

This PR allows users to adjust the `min-width` value using a CSS variable.

GitHub issue number or Jira issue URL: N/A

## Other information
