### PR TITLE
fix(component/listbox): standardise focus status

### DIFF
--- a/packages/styles/components/_c.listbox.scss
+++ b/packages/styles/components/_c.listbox.scss
@@ -38,7 +38,8 @@
     position: relative;
 
     &:not(#{$selector-empty}):not(.is-disabled):hover,
-    &:has(.mc-listbox__input:focus) {
+    &:has(.mc-listbox__input:focus),
+    &:has(.mc-listbox__label:focus) {
       background-color: $color-listbox-tile-hover-background;
       box-shadow: inset 9px 0 0 -7px $color-listbox-tile-shadow;
     }
@@ -88,6 +89,7 @@
     color: currentColor;
     cursor: pointer;
     white-space: nowrap;
+    outline: transparent;
 
     @at-root button#{&} {
       background: none;


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

### Standardise focus status

In the previous PR, the case of the "Actions" version of the Listbox was not dealt with.
In fact, in the context of the Listbox (Actions) the focus is not on inputs _(because there are none)_ but rather on focusable elements of the `<label>` ou `<a href="#">` type which have the class `mc-listbox__label`.

This PR corrects this shortcoming and standardises the focus behaviour between the "Options" and "Actions" variations of the component.

GitHub issue number or Jira issue URL: N/A

## Other information
