### PR TITLE
fix(component/textarea): adjust text color to disabled state

### DIFF
--- a/packages/styles/components/_c.textarea.scss
+++ b/packages/styles/components/_c.textarea.scss
@@ -1,10 +1,10 @@
 /* mqp:start */
 .mc-textarea {
-  $border-width: get-border('s');
+  $border-width: get-border("s");
 
   @include reset-input;
-  @include set-font-scale('05', 'm');
-  @include set-border-radius('m');
+  @include set-font-scale("05", "m");
+  @include set-border-radius("m");
 
   display: block;
   width: 100%;
@@ -15,8 +15,7 @@
   transition: all ease 200ms;
   max-width: 100%;
   // remove border height and center baseline optically
-  padding:
-    calc(#{$mu075} - 0.125em - #{$border-width}) $mu075
+  padding: calc(#{$mu075} - 0.125em - #{$border-width}) $mu075
     calc(#{$mu075} + 0.125em - #{$border-width});
 
   &:hover {
@@ -42,6 +41,7 @@
   &:disabled {
     border-color: $color-input-disabled-background;
     background: $color-input-disabled-background;
+    color: $color-input-placeholder;
     cursor: not-allowed;
   }
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

Adjust text color to disabled state

GitHub issue number or Jira issue URL: N/A

## Other information
