### PR TITLE
feat(buttons): promotes aria-disabled for buttons for A11Y sake

### DIFF
--- a/packages/styles/settings-tools/_s.buttons.scss
+++ b/packages/styles/settings-tools/_s.buttons.scss
@@ -141,7 +141,8 @@ $button-color-default: map-get(get-token(color, button, "solid"), "font");
     $disabled-props: map-get($props, "disabled");
 
     &:disabled,
-    &.is-disabled {
+    &.is-disabled,
+    &[aria-disabled="true"] {
       background-color: map-get($disabled-props, "background");
       border-color: transparent;
       color: map-get($disabled-props, "font");

--- a/src/docs/Components/Buttons/accessibility.mdx
+++ b/src/docs/Components/Buttons/accessibility.mdx
@@ -35,4 +35,22 @@ order: 4
   <br />
 </HintItem>
 
+<HintItem>
+  When designing a form, with a logic that enables or disables the submit button following the business rules, it is
+  recommended to use <code>aria-disabled="true"</code> instead of <code>disabled="true"</code>.
+  The main advantage is the button stays focusable, letting any person with an assistive technology to discover
+  the existence of the button, even when it is disabled.
+  <br />
+  It is then the responsibility of the developer to manage the submission of the form,
+  as <code>aria-disabled="true"</code>
+  let the possibility to the user to use the button, and therefore submit the form.
+  <br />
+  A few resources about this pattern:
+  <ul>
+    <li><a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled">MDN</a></li>
+    <li><a href="https://css-tricks.com/making-disabled-buttons-more-inclusive/">Making disabled buttons more inclusive,
+      on CSS-Tricks</a></li>
+  </ul>
+</HintItem>
+
 <Story id="action-button--markup" />

--- a/src/docs/Contributing/Developers/InstallForDev/index.mdx
+++ b/src/docs/Contributing/Developers/InstallForDev/index.mdx
@@ -22,7 +22,7 @@ npm i -g yarn
 
 ### Note about the project architecture
 
-The project use a monorepo architecture using [lerna](https://github.com/lerna/lerna/).
+The project uses a monorepo architecture using [lerna](https://github.com/lerna/lerna/).
 Lerna help us to manage the distribution and the versioning of multiple packages into the same repository.
 It also create symlink between the individual packages nodes_modules so they can be used in one another as npm dependencies.
 
@@ -66,7 +66,7 @@ Lunch the dev server:
 yarn develop
 ```
 
-## Targeting compillation of selected previews directory
+## Targeting compilation of selected previews directory
 
 Compiling previews take a long time, and most of the time you need only to compile the previews you are working on.
 
@@ -90,7 +90,7 @@ yarn css:lint
 
 and make the required changes.
 
-stylelint `fix` and `lint` are run at pre-commit, so you can't commit uggly stuffs ;).
+stylelint `fix` and `lint` are run at pre-commit, so you can't commit ugly stuffs ;).
 
 ## Create a production build :
 


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [x] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

<!-- Please describe the current behavior that you are modifying or a link to a relevant issue. -->

The description is documented in the committed file `accessibility.mdx`.

In a few words, this encourages the usage of `aria-disabled="true"` on buttons, for them to stay focusable for people with disabilities. 

The CSS of buttons have been updated accordingly.

GitHub issue number or Jira issue URL: N/A

## Other information

The pertinence of the pattern has been discussed with @BertrandLaot.

IMPORTANT: As I have not been able to run the design system locally, it is highly recommended to try the changes on a working machine.
