### PR TITLE
feat(type): add declaration type for exposed "css-dev-tools" plugins

### DIFF
--- a/packages/css-dev-tools/postcssPluginConfig.d.ts
+++ b/packages/css-dev-tools/postcssPluginConfig.d.ts
@@ -1,0 +1,5 @@
+declare module '@mozaic-ds/css-dev-tools/postcssPluginConfig' {
+  import { AcceptedPlugin } from 'postcss'
+  const x: AcceptedPlugin[]
+  export = x
+}

--- a/packages/css-dev-tools/sassConfig.d.ts
+++ b/packages/css-dev-tools/sassConfig.d.ts
@@ -1,0 +1,8 @@
+declare module '@mozaic-ds/css-dev-tools/sassConfig' {
+  const x: {
+    includePaths: string[]
+    outputStyle: 'expanded'
+    indentWidth: number
+  }
+  export = x
+}


### PR DESCRIPTION
## I have read [the contributing guidelines](https://mozaic.adeo.cloud/Contributing/)

- [ ] Yes
- [ ] No

## Does this PR introduce a [breaking change](https://mozaic.adeo.cloud/Contributing/Developers/GitConventions/#breaking-changes-)?

- [ ] Yes
- [x] No

## Describe the changes

### Situation
* Il est nécessaire de déclarer les 2 configurations dans le projet
    * `@mozaic-ds/css-dev-tools/sassConfig`
    * `@mozaic-ds/css-dev-tools/postcssPluginConfig`
* 90% (estimation) des projets sont en **TypeScript**
    (Levant des erreurs de typage si on importe du JS non typé)
* Majoritairement avec des **Linter**s
    (Levant des erreurs si on bypasse le typage)

Donc la grande majorité des projets possèdent une dette lié au typage de ce module `@mozaic-ds/css-dev-tools`

### Solution

Le plus simple (maintenable) à court therme serait de déclarer leur typage.

(L'idéal serait de convertir en TypeScript le module (ou projet). Mais bon cela demanderait beaucoup de travail, pour quelque chose qui ne change quasiment jamais).

## Other information

[`kobi-getstarted-microfront-vuejs`](https://github.com/adeo/kobi-getstarted-microfront-vuejs/blob/main/vite.config.ts#L6)